### PR TITLE
Remove stray semicolon in `react-charts` code listing in README

### DIFF
--- a/packages/react-charts/README.md
+++ b/packages/react-charts/README.md
@@ -14,9 +14,9 @@ Add or omit granular `d3-*` modules and their matching type packages with the
 chart's actual imports.
 
 ```tsx
-import { Chart } from '@tanstack/react-charts'
+import { Chart } from '@tanstack/react-charts';
 
-;<Chart
+<Chart
   definition={definition}
   input={{ rows, metric }}
   aspectRatio={16 / 9}
@@ -33,7 +33,7 @@ import { Chart } from '@tanstack/react-charts'
 Switch only the import to opt into Canvas:
 
 ```tsx
-import { Chart } from '@tanstack/react-charts/canvas'
+import { Chart } from '@tanstack/react-charts/canvas';
 ```
 
 The default entry remains SVG-based. `@tanstack/react-charts/core` accepts an

--- a/packages/react-charts/README.md
+++ b/packages/react-charts/README.md
@@ -14,7 +14,7 @@ Add or omit granular `d3-*` modules and their matching type packages with the
 chart's actual imports.
 
 ```tsx
-import { Chart } from '@tanstack/react-charts';
+import { Chart } from '@tanstack/react-charts'
 
 <Chart
   definition={definition}
@@ -33,7 +33,7 @@ import { Chart } from '@tanstack/react-charts';
 Switch only the import to opt into Canvas:
 
 ```tsx
-import { Chart } from '@tanstack/react-charts/canvas';
+import { Chart } from '@tanstack/react-charts/canvas'
 ```
 
 The default entry remains SVG-based. `@tanstack/react-charts/core` accepts an


### PR DESCRIPTION
Hello, there seems to be a stray semicolon in the first code example on the `react-charts` readme page.

Cheers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the React usage example to improve JSX snippet formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->