### PR TITLE
Fix universal release provenance

### DIFF
--- a/.changeset/universal-chart-barrels.md
+++ b/.changeset/universal-chart-barrels.md
@@ -2,6 +2,8 @@
 '@tanstack/charts': minor
 ---
 
-Add environment-safe `/universal` and `/types` entry points, including generic
-tooltip-extension token contracts for non-DOM hosts, while preserving the
-existing browser-oriented root exports.
+Rename the environment-safe `/portable` entry from `0.1.0` to `/universal`.
+Replace `@tanstack/charts/portable` imports with `@tanstack/charts/universal`.
+The `/types` entry and browser-oriented root exports remain unchanged. The
+universal type surface now includes generic tooltip-extension token contracts
+for non-DOM hosts.

--- a/API-FRICTION.md
+++ b/API-FRICTION.md
@@ -191,7 +191,7 @@ Each entry records:
 | F-153 | Changesets left release-facing version claims behind     | Tooling/Release | resolved   |
 | F-154 | Root barrels crossed the browser host boundary           | API/Tooling     | resolved   |
 | F-155 | Optional tooltip code burdened every chart consumer      | API             | resolved   |
-| F-156 | Releases stranded manual Unreleased migration notes      | Tooling/Release | resolved   |
+| F-156 | Releases stranded manual Unreleased migration notes      | Tooling/Release | monitoring |
 | F-157 | Conformance monitoring blocked unrelated changes         | Tooling         | resolved   |
 
 ## Findings
@@ -3740,24 +3740,34 @@ Each entry records:
 
 ### F-156 — Releases stranded manual Unreleased migration notes
 
-- Status: resolved
+- Status: monitoring
 - Severity: high
 - Owner: Tooling/Release
 - Observed in: rebasing the tooltip and compact-scale release onto the
-  Changesets-based `0.0.2` release flow
+  Changesets-based `0.0.2` release flow, then landing the universal-entry rename
+  after the `0.1.0` version pull request had merged and published
 - Friction: the root changelog held the complete human- and agent-readable
   migration under `## Unreleased`, while Changesets generated package sections
   and prepended the new version without consuming that section. The resulting
   release would leave the migration under an obsolete heading instead of the
-  version users were upgrading to.
+  version users were upgrading to. A later feature branch exposed the inverse
+  race: its pending universal-entry note merged into the already-published
+  `0.1.0` section after the version pull request had consumed `## Unreleased`,
+  even though its remaining changeset correctly targeted `0.2.0`.
 - Decision: when synchronizing a new root release, move the body of
   `## Unreleased` into the generated version section and remove the pending
   heading. Package-specific changesets retain the core, React, and compact-scale
-  migration instructions in their published package changelogs.
+  migration instructions in their published package changelogs. A feature pull
+  request that crosses a published version boundary must re-establish
+  `## Unreleased`, keep the published section immutable, and describe migration
+  from the package version that actually reached npm.
 - Verification: the focused changelog synchronization regression moves pending
   breaking-change notes under the generated version, removes `## Unreleased`,
   preserves earlier releases, and includes the migration in extracted GitHub
-  release notes.
+  release notes. The universal follow-up restores its note under
+  `## Unreleased`, leaves the published `0.1.0` section accurate, and reports a
+  single minor `@tanstack/charts` release from `0.1.0` to `0.2.0`; the docs,
+  bundle, changelog-consumption, and release-artifact gates pass.
 
 ### F-157 — Conformance monitoring blocked unrelated changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Breaking changes
+
+#### Universal entry
+
+Replace `@tanstack/charts/portable` imports from `0.1.0` with
+`@tanstack/charts/universal`. The browser-oriented `@tanstack/charts` root and
+the environment-safe `@tanstack/charts/types` entry remain unchanged.
+
 ## 0.1.0
 
 ### @tanstack/charts
@@ -164,11 +174,6 @@ runtime. Other framework adapters retain their existing entry points and only
 require the chart-definition migration above.
 
 ### Added
-
-- Added environment-safe `@tanstack/charts/universal` and
-  `@tanstack/charts/types` entry points for cross-runtime chart definitions,
-  scene compilation, and extension contracts. The existing `@tanstack/charts`
-  root remains the browser-oriented entry point.
 
 - Added the optional compact scale package:
 

--- a/benchmarks/bundle-size/universal-baseline.json
+++ b/benchmarks/bundle-size/universal-baseline.json
@@ -4,7 +4,7 @@
   "bundles": {
     "D3-scale line scene": {
       "bytes": 35111,
-      "gzip": 13765
+      "gzip": 13764
     },
     "D3-scale line + static SVG": {
       "bytes": 38163,
@@ -40,7 +40,7 @@
     },
     "D3 linear-scale line scene": {
       "bytes": 35043,
-      "gzip": 13728
+      "gzip": 13727
     }
   }
 }

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -12,14 +12,14 @@ evidence without turning untested behavior into a checkmark.
 
 | Library                                                                                | Package              | Measured source     |
 | -------------------------------------------------------------------------------------- | -------------------- | ------------------- |
-| [TanStack Charts](./overview.md)                                                       | `@tanstack/charts`   | workspace `4a8a256` |
+| [TanStack Charts](./overview.md)                                                       | `@tanstack/charts`   | workspace `2be6729` |
 | [Chart.js](https://www.chartjs.org/docs/latest/)                                       | `chart.js`           | npm `4.5.1`         |
 | [Apache ECharts](https://echarts.apache.org/handbook/en/best-practices/canvas-vs-svg/) | `echarts`            | npm `6.1.0`         |
 | [Recharts](https://recharts.github.io/en-US/)                                          | `recharts`           | npm `3.10.1`        |
 | [Observable Plot](https://observablehq.com/plot/features/plots)                        | `@observablehq/plot` | npm `0.6.17`        |
 
 The competitor versions are exact package pins, not latest versions inferred
-at page render time. The measured TanStack workspace revision is `4a8a256`.
+at page render time. The measured TanStack workspace revision is `2be6729`.
 
 ## Capability matrix
 

--- a/packages/charts-core/docs/comparison.md
+++ b/packages/charts-core/docs/comparison.md
@@ -12,14 +12,14 @@ evidence without turning untested behavior into a checkmark.
 
 | Library                                                                                | Package              | Measured source     |
 | -------------------------------------------------------------------------------------- | -------------------- | ------------------- |
-| [TanStack Charts](./overview.md)                                                       | `@tanstack/charts`   | workspace `4a8a256` |
+| [TanStack Charts](./overview.md)                                                       | `@tanstack/charts`   | workspace `2be6729` |
 | [Chart.js](https://www.chartjs.org/docs/latest/)                                       | `chart.js`           | npm `4.5.1`         |
 | [Apache ECharts](https://echarts.apache.org/handbook/en/best-practices/canvas-vs-svg/) | `echarts`            | npm `6.1.0`         |
 | [Recharts](https://recharts.github.io/en-US/)                                          | `recharts`           | npm `3.10.1`        |
 | [Observable Plot](https://observablehq.com/plot/features/plots)                        | `@observablehq/plot` | npm `0.6.17`        |
 
 The competitor versions are exact package pins, not latest versions inferred
-at page render time. The measured TanStack workspace revision is `4a8a256`.
+at page render time. The measured TanStack workspace revision is `2be6729`.
 
 ## Capability matrix
 


### PR DESCRIPTION
## What

- document the published `0.1.0` `/portable` → `0.2.0` `/universal` migration in `CHANGELOG.md` and the pending changeset
- move the universal note out of the already-published `0.1.0` section
- refresh comparison-source and universal-bundle provenance, then sync generated package docs
- record the observed version-PR race in the existing release-friction finding

## Why

PR #20 merged immediately after `0.1.0` was published. The remaining changeset correctly targets `0.2.0`, but the release note and evidence still described the pre-publish branch state.

## Checks

- `pnpm exec changeset status` — `@tanstack/charts` `0.1.0` → `0.2.0` minor
- `pnpm docs:check`
- `pnpm bundle:check`
- `pnpm benchmark:check`
- `pnpm release:artifacts`
- `pnpm release:check`
- focused changelog, workflow, and API-friction tests — 14/14 passed
