### PR TITLE
Fix catalog static checks

### DIFF
--- a/API-FRICTION.md
+++ b/API-FRICTION.md
@@ -4409,8 +4409,10 @@ Each entry records:
 - Verification: the focused TypeScript build reports zero diagnostics; source
   loader, artifact, source-file, and source-view suites pass; and the
   schema-v4 catalog build publishes all 102 cases with valid recursive source
-  closures. Chromium quick-profile checks pass visual and semantic interaction
-  scenarios for all ten migrated cases at 320px and 640px across both data
-  revisions. Their authored-source ratios remain 0.80–1.17× of the selected
-  references, and the measured isolated bundles include React rather than
-  silently treating it as benchmark-external infrastructure.
+  closures. The definition-shape check follows migrated `view.tsx` modules, and
+  the loading graph accepts their lazy `.tsx?raw` source entries. Chromium
+  quick-profile checks pass visual and semantic interaction scenarios for all
+  ten migrated cases at 320px and 640px across both data revisions. Their
+  authored-source ratios remain 0.80–1.17× of the selected references, and the
+  measured isolated bundles include React rather than silently treating it as
+  benchmark-external infrastructure.

--- a/scripts/catalog-definition-shapes.test.mjs
+++ b/scripts/catalog-definition-shapes.test.mjs
@@ -26,9 +26,23 @@ const responsiveDefinitions = [
 describe('catalog definition shapes', () => {
   it('uses static definitions unless the chart reads build context', async () => {
     const entries = await readdir(casesDirectory, { withFileTypes: true })
-    const files = entries
+    const caseDirectories = entries
       .filter((entry) => entry.isDirectory())
-      .map((entry) => path.join(casesDirectory, entry.name, 'tanstack.ts'))
+      .map((entry) => path.join(casesDirectory, entry.name))
+    const files = (
+      await Promise.all(
+        caseDirectories.map(async (directory) => {
+          const caseEntries = await readdir(directory, { withFileTypes: true })
+          return caseEntries
+            .filter(
+              (entry) =>
+                entry.isFile() &&
+                (entry.name === 'tanstack.ts' || entry.name === 'view.tsx'),
+            )
+            .map((entry) => path.join(directory, entry.name))
+        }),
+      )
+    ).flat()
 
     const classification = {
       parameterless: [],
@@ -60,7 +74,6 @@ function classifyDefinitions(relativePath, source, classification) {
     source,
     ts.ScriptTarget.Latest,
     true,
-    ts.ScriptKind.TS,
   )
 
   function visit(node) {

--- a/scripts/check-catalog-loading.mjs
+++ b/scripts/check-catalog-loading.mjs
@@ -313,8 +313,8 @@ function isDemoDatasetPayload(module) {
 function isCatalogSourceModule(module) {
   const value = normalizePath(module)
   return (
-    /\/benchmarks\/conformance\/(?:cases|shared)\/.+\.ts\?raw$/.test(value) &&
-    !value.endsWith('.test.ts?raw')
+    /\/benchmarks\/conformance\/(?:cases|shared)\/.+\.tsx?\?raw$/.test(value) &&
+    !/\.test\.tsx?\?raw$/.test(value)
   )
 }
 


### PR DESCRIPTION
## Summary

- follow React-migrated view.tsx definitions in the catalog shape contract
- accept lazy TSX raw source modules in the catalog loading graph
- update F-178 verification evidence

## Root cause

The React example migration moved twelve static chart definitions from tanstack.ts into view.tsx, while the static gates still assumed every definition and raw source module used .ts.

## Verification

- pnpm run validate
- pnpm exec vitest run scripts/catalog-definition-shapes.test.mjs
- pnpm catalog:loading:check
- Prettier and git diff checks