### PR TITLE
Fix release version token matching

### DIFF
--- a/API-FRICTION.md
+++ b/API-FRICTION.md
@@ -230,6 +230,7 @@ Each entry records:
 | F-192 | SVG letterboxing shifted pointer hit testing              | API             | resolved   |
 | F-193 | Fixed catalog height hid compact responsive examples      | Tooling/App     | resolved   |
 | F-194 | Behavior runs omitted the interactive input               | Tooling         | resolved   |
+| F-195 | Release versions matched dependency substrings            | Tooling         | resolved   |
 
 ## Findings
 
@@ -4842,3 +4843,21 @@ Each entry records:
   passes at 320 and 640 pixels across both revisions; reverting the runtime fix
   makes the same scenario report Aug 5 or Aug 6. Static visual measurements and
   public catalog mounts retain their original dimensions.
+
+### F-195 — Release version matching collided with dependency versions
+
+- Status: resolved
+- Severity: high
+- Owner: Tooling
+- Observed in: releasing 0.6.1 after the SVG pointer fix
+- Friction: the release synchronizer counted versions with raw substring
+  matching. Observable Plot's documented `0.6.17` version therefore counted as
+  an existing `0.6.1` release reference and stopped the Changesets workflow
+  before it could create the version pull request.
+- Decision: count and replace complete version tokens while still accepting the
+  repository's `v0.6.1` tag references. Ignore longer semantic versions and
+  prerelease suffixes that merely share a prefix.
+- Verification: the release-version unit regression advances TanStack Charts
+  from 0.6.0 to 0.6.1 while leaving Observable Plot 0.6.17 unchanged. The
+  release workflow can create the 0.6.1 version pull request from the same
+  changeset.

--- a/scripts/sync-release-version.mjs
+++ b/scripts/sync-release-version.mjs
@@ -27,8 +27,10 @@ export function syncReleaseVersionReference(
   path,
   expectedReferences,
 ) {
-  const previousReferences = source.split(previousVersion).length - 1
-  const currentReferences = source.split(version).length - 1
+  const previousPattern = releaseVersionPattern(previousVersion)
+  const currentPattern = releaseVersionPattern(version)
+  const previousReferences = [...source.matchAll(previousPattern)].length
+  const currentReferences = [...source.matchAll(currentPattern)].length
   const expectedCount = `${expectedReferences} ${
     expectedReferences === 1 ? 'reference' : 'references'
   }`
@@ -51,7 +53,12 @@ export function syncReleaseVersionReference(
     0,
     `${path} mixes release versions ${previousVersion} and ${version}`,
   )
-  return source.replaceAll(previousVersion, version)
+  return source.replace(previousPattern, version)
+}
+
+function releaseVersionPattern(version) {
+  const escaped = version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`(?<![0-9.])${escaped}(?![0-9A-Za-z.-])`, 'g')
 }
 
 export async function syncReleaseVersion({

--- a/scripts/sync-release-version.test.mjs
+++ b/scripts/sync-release-version.test.mjs
@@ -70,6 +70,21 @@ describe('release version synchronization', () => {
     ).toBe(synced)
   })
 
+  it('does not treat a dependency version as the release version', () => {
+    const source =
+      'TanStack Charts `0.6.0`; tag /v0.6.0/; Observable Plot `0.6.17`.'
+
+    expect(
+      syncReleaseVersionReference(
+        source,
+        '0.6.0',
+        '0.6.1',
+        'docs/comparison.md',
+        2,
+      ),
+    ).toBe('TanStack Charts `0.6.1`; tag /v0.6.1/; Observable Plot `0.6.17`.')
+  })
+
   it('rejects a release-facing file with no recognized version', () => {
     expect(() =>
       syncReleaseVersionReference(


### PR DESCRIPTION
Fix the release synchronizer so a target version such as `0.6.1` does not match an unrelated dependency version such as Observable Plot `0.6.17`.

This unblocks the Changesets version PR after Release run 30763751052 failed on the false mixed-version assertion.

Validation:
- exact version collision regression
- release workflow tests
- full `pnpm validate` (17 targets, 775 DOM tests)