### PR TITLE
Clarify motion animation ownership

### DIFF
--- a/.changeset/clean-motion-ownership.md
+++ b/.changeset/clean-motion-ownership.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/charts': patch
+---
+
+Clarify that each chart host has one animation owner: the default SVG renderer
+uses `animate`, while `motion()` ignores it and uses definition-level motion
+declarations.

--- a/API-FRICTION.md
+++ b/API-FRICTION.md
@@ -4722,13 +4722,20 @@ Each entry records:
   reduced-motion handling, and resize motion. Keep semantic timing in chart,
   mark, datum, axis, label, and focus definitions. Keep the SVG driver and
   reconciler integration internal. Retain the scalar physics sampler as the
-  separate `@tanstack/charts/spring` capability.
+  separate `@tanstack/charts/spring` capability. Retain the lightweight
+  `animate` path for the default SVG renderer, but enforce one animation owner
+  per host: `motion()` ignores legacy animation options and reads declarative
+  motion policy from the chart definition. A definition-level `motion`
+  declaration configures that renderer; it does not select it.
 - Verification: all catalog, POC, packed-consumer, and unit-test callers use
   `motion()`. The public `/motion` entry exports one value plus its option and
   renderer-neutral definition types; legacy aliases and low-level driver types
   no longer appear in the package contract. Documentation covers the one-path
   setup, override cascade, renderer compatibility, accessibility behavior, and
-  migration from duration-only focus transitions.
+  migration from duration-only focus transitions. The motion renderer
+  integration test mounts a definition containing both legacy `animate` and a
+  conflicting definition-level motion duration, then verifies that the
+  host-level motion renderer owns the transition timing.
 
 ### F-190 — Static conformance sampled active motion
 

--- a/benchmarks/comparison/bundle-baseline.json
+++ b/benchmarks/comparison/bundle-baseline.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 3,
-  "generatedAt": "2026-08-02T19:11:27.130Z",
+  "generatedAt": "2026-08-02T20:16:51.564Z",
   "packageVersions": {
-    "tanstack": "0.6.0",
+    "tanstack": "0.6.1",
     "chartjs": "4.5.1",
     "echarts": "6.1.0",
     "recharts": "3.10.1",
@@ -11,7 +11,7 @@
   "sources": {
     "tanstack": {
       "kind": "workspace",
-      "revision": "eaa96a340cde6f07a1b7edb6a111e2a52d7d1c03"
+      "revision": "0eeec7dbe62d362839820b953a731ae0596206ee"
     },
     "chartjs": {
       "kind": "package",

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -12,14 +12,14 @@ untested behavior into a checkmark.
 
 | Library                                                                                | Package              | Measured source     |
 | -------------------------------------------------------------------------------------- | -------------------- | ------------------- |
-| [TanStack Charts](./overview.md)                                                       | `@tanstack/charts`   | workspace `eaa96a3` |
+| [TanStack Charts](./overview.md)                                                       | `@tanstack/charts`   | workspace `0eeec7d` |
 | [Chart.js](https://www.chartjs.org/docs/latest/)                                       | `chart.js`           | npm `4.5.1`         |
 | [Apache ECharts](https://echarts.apache.org/handbook/en/best-practices/canvas-vs-svg/) | `echarts`            | npm `6.1.0`         |
 | [Recharts](https://recharts.github.io/en-US/)                                          | `recharts`           | npm `3.10.1`        |
 | [Observable Plot](https://observablehq.com/plot/features/plots)                        | `@observablehq/plot` | npm `0.6.17`        |
 
 The competitor versions are exact package pins, not latest versions inferred
-at page render time. The measured TanStack workspace revision is `eaa96a3`.
+at page render time. The measured TanStack workspace revision is `0eeec7d`.
 
 ## Capability matrix
 

--- a/docs/guides/dynamic-data-and-animation.md
+++ b/docs/guides/dynamic-data-and-animation.md
@@ -135,8 +135,10 @@ const host = mountChartRenderer(container, {
 })
 ```
 
-Choose either `animate` with the default SVG host or `motion()` as the renderer
-for a chart. Do not enable both.
+Each host has one animation owner. The default SVG renderer uses `animate`.
+When `motion()` is the renderer, it ignores `animate` and uses motion
+declarations from the definition. A `motion` declaration configures the motion
+renderer; it does not select it.
 
 Motion declarations can live on the chart, a mark, an axis, its ticks, tick
 labels, or axis label. A callback can specialize `enter`, `update`, and `exit`

--- a/packages/charts-core/docs/comparison.md
+++ b/packages/charts-core/docs/comparison.md
@@ -12,14 +12,14 @@ untested behavior into a checkmark.
 
 | Library                                                                                | Package              | Measured source     |
 | -------------------------------------------------------------------------------------- | -------------------- | ------------------- |
-| [TanStack Charts](./overview.md)                                                       | `@tanstack/charts`   | workspace `eaa96a3` |
+| [TanStack Charts](./overview.md)                                                       | `@tanstack/charts`   | workspace `0eeec7d` |
 | [Chart.js](https://www.chartjs.org/docs/latest/)                                       | `chart.js`           | npm `4.5.1`         |
 | [Apache ECharts](https://echarts.apache.org/handbook/en/best-practices/canvas-vs-svg/) | `echarts`            | npm `6.1.0`         |
 | [Recharts](https://recharts.github.io/en-US/)                                          | `recharts`           | npm `3.10.1`        |
 | [Observable Plot](https://observablehq.com/plot/features/plots)                        | `@observablehq/plot` | npm `0.6.17`        |
 
 The competitor versions are exact package pins, not latest versions inferred
-at page render time. The measured TanStack workspace revision is `eaa96a3`.
+at page render time. The measured TanStack workspace revision is `0eeec7d`.
 
 ## Capability matrix
 

--- a/packages/charts-core/docs/guides/dynamic-data-and-animation.md
+++ b/packages/charts-core/docs/guides/dynamic-data-and-animation.md
@@ -135,8 +135,10 @@ const host = mountChartRenderer(container, {
 })
 ```
 
-Choose either `animate` with the default SVG host or `motion()` as the renderer
-for a chart. Do not enable both.
+Each host has one animation owner. The default SVG renderer uses `animate`.
+When `motion()` is the renderer, it ignores `animate` and uses motion
+declarations from the definition. A `motion` declaration configures the motion
+renderer; it does not select it.
 
 Motion declarations can live on the chart, a mark, an axis, its ticks, tick
 labels, or axis label. A callback can specialize `enter`, `update`, and `exit`

--- a/packages/charts-core/src/motion.test.ts
+++ b/packages/charts-core/src/motion.test.ts
@@ -4,6 +4,7 @@ import { barY } from './bar'
 import { dot } from './dot'
 import { lineY } from './line'
 import { motion } from './motion'
+import { mountChartRenderer } from './renderer'
 import { createChartScene, defineChart } from './scene'
 import { chartSceneSource } from './scene-source'
 import { renderChartSvg } from './svg'
@@ -70,6 +71,62 @@ describe('SVG motion', () => {
     ).toBe(false)
     adoptedSurface.destroy()
     request.mockRestore()
+  })
+
+  it('is the sole animation owner when the definition also enables animate', () => {
+    const makeDefinition = (value: number) =>
+      defineChart({
+        animate: { duration: 1, easing: 'linear' },
+        motion: {
+          transition: { type: 'tween', duration: 100, easing: 'linear' },
+        },
+        marks: [
+          barY([{ id: 'a', category: 'A', value }], {
+            x: 'category',
+            y: 'value',
+            key: 'id',
+          }),
+        ],
+        x: { scale: scaleBand().domain(['A']) },
+        y: { scale: scaleLinear().domain([0, 100]) },
+        guides: false,
+      })
+    const firstDefinition = makeDefinition(20)
+    const nextDefinition = makeDefinition(80)
+    const firstScene = createChartScene(firstDefinition, {
+      width: 300,
+      height: 200,
+    })
+    const nextScene = createChartScene(nextDefinition, {
+      width: 300,
+      height: 200,
+    })
+    const container = document.createElement('div')
+    const renderer = motion({ initial: false })
+    const options = {
+      definition: firstDefinition,
+      renderer,
+      width: 300,
+      height: 200,
+      ariaLabel: 'Single animation owner',
+    }
+    const frames = installFrames()
+    const host = mountChartRenderer(container, options)
+
+    host.update({ ...options, definition: nextDefinition })
+    frames.run(0)
+    frames.run(50)
+
+    const rectangle = container.querySelector<SVGRectElement>(
+      'g.ts-chart__bar-y > rect',
+    )
+    expect(Number(rectangle?.getAttribute('y'))).toBeCloseTo(
+      ((firstScene.points[0]?.y ?? 0) + (nextScene.points[0]?.y ?? 0)) / 2,
+    )
+
+    frames.run(100)
+    host.destroy()
+    frames.restore()
   })
 
   it('grows bars from their semantic baseline with bounded datum timing', () => {


### PR DESCRIPTION
## Summary

- define one animation owner per chart host
- document that the default SVG renderer uses `animate`
- verify that `motion()` ignores legacy animation timing and uses definition-level motion policy

## Release

Patch the fixed Charts package set to 0.6.2.

## Validation

- `pnpm run validate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how chart animation is controlled across rendering modes.
  * The default SVG renderer uses `animate`, while the motion renderer uses motion settings defined in the chart configuration.
  * Clarified that motion settings configure the motion renderer but do not activate it.

* **Bug Fixes**
  * Added verification to ensure animation timing remains consistent when both configuration styles are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->