### PR TITLE
fix: mount chart only in browser for angular adapter

### DIFF
--- a/packages/angular-charts/src/Chart.ts
+++ b/packages/angular-charts/src/Chart.ts
@@ -10,10 +10,10 @@ import {
   ViewChild,
   ViewContainerRef,
   ViewEncapsulation,
+  afterNextRender,
   inject,
 } from '@angular/core'
 import type {
-  AfterViewInit,
   EmbeddedViewRef,
   OnChanges,
   OnDestroy,
@@ -123,7 +123,7 @@ export class Chart<
   TXValue extends ChartValue = ChartValue,
   TYValue extends ChartValue = ChartValue,
 >
-  implements OnChanges, AfterViewInit, OnDestroy
+  implements OnChanges, OnDestroy
 {
   @Input({ required: true })
   declare options: ChartOptions<TDatum, TXValue, TYValue>
@@ -172,6 +172,12 @@ export class Chart<
     ChartTooltipBodyTemplateContext<TDatum, TXValue, TYValue>
   >
 
+  constructor() {
+    afterNextRender(() => {
+      this.adapter?.mount(this.surface.nativeElement)
+    })
+  }
+
   ngOnChanges(_changes: SimpleChanges) {
     if (!this.options) return
     const layout = resolveChartAdapterLayout(this.options)
@@ -192,10 +198,6 @@ export class Chart<
       .join(';')
 
     this.updateAdapter()
-  }
-
-  ngAfterViewInit() {
-    this.adapter?.mount(this.surface.nativeElement)
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
Closes #56. Chart mount is only called in the browser using `afterNextRender`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart initialization for more consistent rendering when views load.
  * Enhanced lifecycle handling to help charts appear reliably during application startup.
  * Preserved proper cleanup when charts are removed or destroyed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->