### PR TITLE
fix(benchmarks/conformance/cases): pin 'en-US' so catalog rendering is locale-independent

### DIFF
--- a/.changeset/pin-catalog-date-locale.md
+++ b/.changeset/pin-catalog-date-locale.md
@@ -1,0 +1,8 @@
+---
+'@tanstack/react-charts-catalog': patch
+---
+
+Format dates and numbers in catalog cases with an explicit `en-US` locale so
+rendered output is identical on every host. Cases such as
+`86-streaming-window-preservation` previously took axis tick labels from the
+machine's locale.

--- a/benchmarks/conformance/cases/103-bubble-map/tanstack.ts
+++ b/benchmarks/conformance/cases/103-bubble-map/tanstack.ts
@@ -55,6 +55,6 @@ const definition = (input: ConformanceInput) =>
 export const mount = tanstackMount(definition, 'World population bubble map', {
   format: ({ datum }) =>
     'properties' in datum && 'population' in datum.properties
-      ? `${datum.properties['Country Name']} · ${datum.properties.population.toLocaleString()} people`
+      ? `${datum.properties['Country Name']} · ${datum.properties.population.toLocaleString('en-US')} people`
       : 'World land',
 })

--- a/benchmarks/conformance/cases/34-pointer-tooltip/plot.ts
+++ b/benchmarks/conformance/cases/34-pointer-tooltip/plot.ts
@@ -33,7 +33,7 @@ export const mount: ConformanceMount = (container, input) => {
             x: 'Date',
             y: 'Close',
             title: (row) =>
-              `Apple: ${row.Close.toLocaleString(undefined, {
+              `Apple: ${row.Close.toLocaleString('en-US', {
                 maximumFractionDigits: 2,
               })}`,
           }),

--- a/benchmarks/conformance/cases/34-pointer-tooltip/tanstack.ts
+++ b/benchmarks/conformance/cases/34-pointer-tooltip/tanstack.ts
@@ -59,7 +59,7 @@ const interactiveTooltip: ChartTooltipOptions<AaplRow> = {
       channel: 'y',
       label: 'Apple',
       text: (point) =>
-        point.datum.Close.toLocaleString(undefined, {
+        point.datum.Close.toLocaleString('en-US', {
           maximumFractionDigits: 2,
         }),
     },

--- a/benchmarks/conformance/cases/35-grouped-tooltip/plot.ts
+++ b/benchmarks/conformance/cases/35-grouped-tooltip/plot.ts
@@ -45,7 +45,7 @@ export const mount: ConformanceMount = (container, input) => {
                   const observation = atDate.find(
                     (candidate) => candidate.industry === industry,
                   )
-                  return `${industry}: ${(observation?.unemployed ?? 0).toLocaleString()}`
+                  return `${industry}: ${(observation?.unemployed ?? 0).toLocaleString('en-US')}`
                 })
                 .join('\n')
             },

--- a/benchmarks/conformance/cases/80-echarts-axis-pointer/echarts.ts
+++ b/benchmarks/conformance/cases/80-echarts-axis-pointer/echarts.ts
@@ -209,7 +209,7 @@ function clearInteractionState(state: InteractionState) {
 }
 
 function tooltipHtml(date: Date, rows: readonly AxisPointerDatum[]) {
-  const title = date.toLocaleDateString(undefined, {
+  const title = date.toLocaleDateString('en-US', {
     month: 'short',
     year: 'numeric',
     timeZone: 'UTC',
@@ -217,7 +217,7 @@ function tooltipHtml(date: Date, rows: readonly AxisPointerDatum[]) {
   const body = rows
     .map(
       (row) =>
-        `<div style="display:flex;align-items:center;gap:6px;margin-top:4px"><span style="width:8px;height:8px;border-radius:2px;background:${axisPointerColors[row.industry]}"></span><span>${row.industry}</span><strong style="margin-left:auto">${row.unemployed.toLocaleString()}</strong></div>`,
+        `<div style="display:flex;align-items:center;gap:6px;margin-top:4px"><span style="width:8px;height:8px;border-radius:2px;background:${axisPointerColors[row.industry]}"></span><span>${row.industry}</span><strong style="margin-left:auto">${row.unemployed.toLocaleString('en-US')}</strong></div>`,
     )
     .join('')
   return `<div data-conformance-tooltip="grouped"><strong>${title}</strong>${body}</div>`

--- a/benchmarks/conformance/cases/82-chart-table-selection/recharts.ts
+++ b/benchmarks/conformance/cases/82-chart-table-selection/recharts.ts
@@ -154,7 +154,7 @@ function ChartTable({ input, onSelectedIdChange }: ChartTableProps) {
                     (row) => penguinSelectionId(row) === selectedId,
                   )
                   return selected
-                    ? `Selected ${penguinSelectionLabel(selected)}: ${selected.body_mass_g.toLocaleString()} g`
+                    ? `Selected ${penguinSelectionLabel(selected)}: ${selected.body_mass_g.toLocaleString('en-US')} g`
                     : 'No observation selected'
                 })()
               : 'No observation selected',

--- a/benchmarks/conformance/cases/82-chart-table-selection/view.tsx
+++ b/benchmarks/conformance/cases/82-chart-table-selection/view.tsx
@@ -108,7 +108,7 @@ const ChartTableExample = forwardRef<
     [input.revision, selectedId],
   )
   const announcement = selectedDatum
-    ? `Selected ${penguinSelectionLabel(selectedDatum)}: ${selectedDatum.body_mass_g.toLocaleString()} g`
+    ? `Selected ${penguinSelectionLabel(selectedDatum)}: ${selectedDatum.body_mass_g.toLocaleString('en-US')} g`
     : 'No observation selected'
 
   useImperativeHandle(
@@ -310,7 +310,7 @@ const ChartTableExample = forwardRef<
                       fontVariantNumeric: 'tabular-nums',
                     }}
                   >
-                    {datum.body_mass_g.toLocaleString()}
+                    {datum.body_mass_g.toLocaleString('en-US')}
                   </td>
                 </tr>
               )

--- a/benchmarks/conformance/cases/83-focus-context-window/plot.ts
+++ b/benchmarks/conformance/cases/83-focus-context-window/plot.ts
@@ -429,7 +429,7 @@ function styleBrush(group: SVGGElement) {
 }
 
 function monthLabel(date: Date) {
-  return date.toLocaleDateString(undefined, {
+  return date.toLocaleDateString('en-US', {
     month: 'short',
     year: 'numeric',
     timeZone: 'UTC',

--- a/benchmarks/conformance/cases/83-focus-context-window/view.tsx
+++ b/benchmarks/conformance/cases/83-focus-context-window/view.tsx
@@ -121,7 +121,7 @@ export function focusContextOverviewDefinition(
           ticks: {
             count: 4,
             format: (value) =>
-              value.toLocaleDateString(undefined, {
+              value.toLocaleDateString('en-US', {
                 month: 'short',
                 timeZone: 'UTC',
               }),
@@ -373,7 +373,7 @@ function rangeLabel(window: FocusContextWindow) {
 }
 
 function monthLabel(date: Date) {
-  return date.toLocaleDateString(undefined, {
+  return date.toLocaleDateString('en-US', {
     month: 'short',
     year: 'numeric',
     timeZone: 'UTC',

--- a/benchmarks/conformance/cases/85-scrollable-resource-lanes/echarts.ts
+++ b/benchmarks/conformance/cases/85-scrollable-resource-lanes/echarts.ts
@@ -527,7 +527,7 @@ function renderDateRuler(ruler: HTMLDivElement, input: ConformanceInput) {
   for (let timestamp = start; timestamp <= end; timestamp += week) {
     const tick = document.createElement('span')
     tick.dataset.conformanceDateTick = ''
-    tick.textContent = new Date(timestamp).toLocaleDateString(undefined, {
+    tick.textContent = new Date(timestamp).toLocaleDateString('en-US', {
       month: 'short',
       day: 'numeric',
       timeZone: 'UTC',

--- a/benchmarks/conformance/cases/85-scrollable-resource-lanes/shell.ts
+++ b/benchmarks/conformance/cases/85-scrollable-resource-lanes/shell.ts
@@ -268,7 +268,7 @@ function renderSchedule(
 }
 
 function formatDate(date: Date) {
-  return date.toLocaleDateString(undefined, {
+  return date.toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
     year: 'numeric',

--- a/benchmarks/conformance/cases/85-scrollable-resource-lanes/tanstack.ts
+++ b/benchmarks/conformance/cases/85-scrollable-resource-lanes/tanstack.ts
@@ -348,7 +348,7 @@ function clipClientSample(
 }
 
 function formatTaskDate(date: Date) {
-  return date.toLocaleDateString(undefined, {
+  return date.toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
     timeZone: 'UTC',

--- a/benchmarks/conformance/cases/86-streaming-window-preservation/echarts.ts
+++ b/benchmarks/conformance/cases/86-streaming-window-preservation/echarts.ts
@@ -84,7 +84,7 @@ export const mount: ConformanceMount = (container, input) => {
       state.viewport = streamingViewportForMode(state.rows, state.viewportMode)
       const added = state.rows.at(-1)
       state.announcement = added
-        ? `Added ${formatStreamingDate(added.date)} (${added.downloads.toLocaleString()} downloads). ${
+        ? `Added ${formatStreamingDate(added.date)} (${added.downloads.toLocaleString('en-US')} downloads). ${
             visibleStreamingData([added], state.viewport).length
               ? 'The new sample is visible.'
               : `It is outside the locked viewport ending ${formatStreamingDate(state.viewport[1])}.`

--- a/benchmarks/conformance/cases/86-streaming-window-preservation/model.ts
+++ b/benchmarks/conformance/cases/86-streaming-window-preservation/model.ts
@@ -82,7 +82,7 @@ export function streamingStatus(state: {
 }
 
 export function formatStreamingDate(date: Date) {
-  return date.toLocaleDateString(undefined, {
+  return date.toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
     timeZone: 'UTC',

--- a/benchmarks/conformance/cases/86-streaming-window-preservation/view.tsx
+++ b/benchmarks/conformance/cases/86-streaming-window-preservation/view.tsx
@@ -68,7 +68,7 @@ export function streamingWindowDefinition(
       axis: {
         ticks: {
           format: (value) =>
-            value.toLocaleDateString(undefined, {
+            value.toLocaleDateString('en-US', {
               month: 'short',
               day: 'numeric',
               timeZone: 'UTC',
@@ -88,7 +88,7 @@ export function streamingWindowDefinition(
     tooltip: {
       use: tooltip,
       format: (point) =>
-        `${formatStreamingDate(point.datum.date)} · ${point.datum.downloads.toLocaleString()} downloads`,
+        `${formatStreamingDate(point.datum.date)} · ${point.datum.downloads.toLocaleString('en-US')} downloads`,
     },
   })
 }
@@ -158,7 +158,7 @@ const StreamingExample = forwardRef<
     setAppended(nextAppended)
     setAnnouncement(
       added
-        ? `Added ${formatStreamingDate(added.date)} (${added.downloads.toLocaleString()} downloads). ${
+        ? `Added ${formatStreamingDate(added.date)} (${added.downloads.toLocaleString('en-US')} downloads). ${
             visibleStreamingData([added], nextViewport).length
               ? 'The new sample is visible.'
               : `It is outside the locked viewport ending ${formatStreamingDate(nextViewport[1])}.`

--- a/benchmarks/conformance/cases/87-echarts-synchronized-cursors/summary.ts
+++ b/benchmarks/conformance/cases/87-echarts-synchronized-cursors/summary.ts
@@ -76,8 +76,8 @@ export function updateSynchronizedSummary(
   const rows = selectSynchronizedCursorData(travelers, input.revision)
   const row = synchronizedCursorDatumAtDate(rows, date)
   summary.date.textContent = `${formatDate(date)}${pinned ? ' · pinned' : ''}`
-  summary.current.textContent = row?.current.toLocaleString() ?? '—'
-  summary.previous.textContent = row?.previous.toLocaleString() ?? '—'
+  summary.current.textContent = row?.current.toLocaleString('en-US') ?? '—'
+  summary.previous.textContent = row?.previous.toLocaleString('en-US') ?? '—'
   summary.root.dataset.date = synchronizedCursorDateKey(date)
   summary.root.dataset.pinned = String(pinned)
 }
@@ -125,7 +125,7 @@ function summaryOutput(document: Document, labelText: string, color: string) {
 }
 
 function formatDate(date: Date) {
-  return date.toLocaleDateString(undefined, {
+  return date.toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
     year: 'numeric',

--- a/benchmarks/conformance/cases/88-echarts-free-cursor/controls.ts
+++ b/benchmarks/conformance/cases/88-echarts-free-cursor/controls.ts
@@ -163,7 +163,7 @@ function sliderLabel(
 }
 
 export function formatFreeCursorValue(axis: string, value: number) {
-  return `${axis} ${value.toLocaleString(undefined, {
+  return `${axis} ${value.toLocaleString('en-US', {
     maximumFractionDigits: 1,
   })}`
 }

--- a/benchmarks/conformance/cases/91-timeline-playback-scrubber/echarts.ts
+++ b/benchmarks/conformance/cases/91-timeline-playback-scrubber/echarts.ts
@@ -116,7 +116,7 @@ function playbackOption(_input: ConformanceInput): PlaybackOption {
       max: playbackEnd.getTime(),
       axisLabel: {
         formatter(value: number) {
-          return new Date(value).toLocaleDateString(undefined, {
+          return new Date(value).toLocaleDateString('en-US', {
             month: 'short',
             day: 'numeric',
             timeZone: 'UTC',

--- a/benchmarks/conformance/cases/91-timeline-playback-scrubber/tanstack.ts
+++ b/benchmarks/conformance/cases/91-timeline-playback-scrubber/tanstack.ts
@@ -73,7 +73,7 @@ export function playbackDefinition(
       axis: {
         ticks: {
           format: (value) =>
-            value.toLocaleDateString(undefined, {
+            value.toLocaleDateString('en-US', {
               month: 'short',
               day: 'numeric',
               timeZone: 'UTC',

--- a/benchmarks/conformance/cases/92-editable-event-range/echarts.ts
+++ b/benchmarks/conformance/cases/92-editable-event-range/echarts.ts
@@ -598,7 +598,7 @@ function sizeView(view: HTMLDivElement, input: ConformanceInput) {
 }
 
 function compactDate(date: Date) {
-  return date.toLocaleDateString(undefined, {
+  return date.toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
     timeZone: 'UTC',

--- a/benchmarks/conformance/cases/92-editable-event-range/tanstack.ts
+++ b/benchmarks/conformance/cases/92-editable-event-range/tanstack.ts
@@ -107,7 +107,7 @@ export function editableEventDefinition(
         axis: {
           ticks: {
             format: (value: Date) =>
-              value.toLocaleDateString(undefined, {
+              value.toLocaleDateString('en-US', {
                 month: 'short',
                 day: 'numeric',
                 timeZone: 'UTC',
@@ -494,7 +494,7 @@ function editableSummaryText(end: Date) {
 }
 
 function compactDate(date: Date) {
-  return date.toLocaleDateString(undefined, {
+  return date.toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
     timeZone: 'UTC',


### PR DESCRIPTION
Several catalog cases format dates and numbers without a locale argument, so their rendered output depends on the machine's locale rather than on the case definition.

The clearest symptom is in the axis tick labels. `86-streaming-window-preservation`, `91-timeline-playback-scrubber` and `92-editable-event-range` render `Oct 6`, `Oct 8`, `Oct 10` on an English host and `10월 6일`, `10월 8일`, `10월 10일` on a Korean one. Since the tick text is part of the SVG, anything that server-renders these cases and commits the result gets a different file depending on who ran the generator.

That is how this surfaced: tanstack.com renders the catalog to static SVGs and hashes them into a revision constant, and its `--check` script reports the committed assets as stale on any non-English machine.

## The change

`'en-US'` on the 29 call sites that omitted a locale, across 21 files. This matches what the rest of the repository already does — every other pinned call in `benchmarks/conformance/cases` uses `en-US`, 96 of them, with no other locale anywhere. The cases already fix their data and pass `timeZone: 'UTC'`, so pinning the locale finishes what those were doing.

Both spellings were present and both are covered: `toLocaleDateString(undefined, …)` and the bare `toLocaleString()`.

Note that `packages/react-charts-catalog/src/cases/*.ts` import `benchmarks/conformance/cases/*/view.tsx` directly, so the `.tsx` files here are shipped components rather than benchmark-only code. That is why this needs a changeset.

## Verification

`pnpm run validate` passes — all 20 Nx targets, including `typecheck`, `react-catalog:check`, `catalog:check`, `format:check` and the unit suite.

Worth flagging: `packages/react-charts-catalog/src/preview.test.tsx` asserts a bundle-size ceiling of 225000 and was **already failing on `main` at 225132** before this change. Replacing `undefined` with `'en-US'` is a net reduction, which brings it under the ceiling and the test now passes. If that ceiling was meant to be raised separately, this PR incidentally resolves it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized date, number, tooltip, axis, table, and accessibility formatting to use the `en-US` locale.
  - Prevented rendered chart output from changing based on the viewer’s runtime or system locale.
  - Improved consistency across chart examples, timelines, cursor interactions, selections, and streaming updates.

- **Documentation**
  - Added release notes documenting the fixed locale behavior for reproducible output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->