### PR TITLE
fix(charts-core): keep zero-valued cells on their stack baseline in the diverging offset

### DIFF
--- a/.changeset/mellow-hamster-zero-stack.md
+++ b/.changeset/mellow-hamster-zero-stack.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/charts': patch
+---
+
+Stacked marks no longer collapse a zero-valued cell to the axis. The default diverging offset now keeps zeros on their series' running baseline, so a stacked area with a zero data point renders a flat segment instead of a spike to zero.

--- a/packages/charts-core/src/stack-internal.test.ts
+++ b/packages/charts-core/src/stack-internal.test.ts
@@ -359,6 +359,106 @@ describe('anchored stacks', () => {
   })
 })
 
+describe('diverging offset zero handling', () => {
+  it('keeps a zero-valued cell on the running top of a positive stack', () => {
+    const positiveRows = [
+      { position: 0, series: 'A', value: 10 },
+      { position: 0, series: 'B', value: 5 },
+      { position: 1, series: 'A', value: 10 },
+      { position: 1, series: 'B', value: 0 },
+    ] as const
+    const extents = stackExtents(
+      positiveRows.map((row, index) => ({ index, ...row })),
+      { order: ['A', 'B'] },
+    )
+
+    expectExtent(extents, 0, 0, 10)
+    expectExtent(extents, 1, 10, 15)
+    expectExtent(extents, 2, 0, 10)
+    expectExtent(extents, 3, 10, 10)
+  })
+
+  it('keeps a zero-valued cell on the running bottom of an exclusively negative stack', () => {
+    const negativeRows = [
+      { position: 0, series: 'A', value: -10 },
+      { position: 0, series: 'B', value: -5 },
+      { position: 1, series: 'A', value: -10 },
+      { position: 1, series: 'B', value: 0 },
+    ] as const
+    const extents = stackExtents(
+      negativeRows.map((row, index) => ({ index, ...row })),
+      { order: ['A', 'B'] },
+    )
+
+    expectExtent(extents, 0, -10, 0)
+    expectExtent(extents, 1, -15, -10)
+    expectExtent(extents, 2, -10, 0)
+    expectExtent(extents, 3, -10, -10)
+  })
+
+  it('leaves a zero unchanged when its series is the only negative one in a mixed stack', () => {
+    const mixedRows = [
+      { position: 0, series: 'A', value: 10 },
+      { position: 0, series: 'B', value: -3 },
+      { position: 1, series: 'A', value: 10 },
+      { position: 1, series: 'B', value: 0 },
+    ] as const
+    const extents = stackExtents(
+      mixedRows.map((row, index) => ({ index, ...row })),
+      { order: ['A', 'B'] },
+    )
+
+    expectExtent(extents, 3, 0, 0)
+  })
+
+  it('leaves an all-zero position unchanged', () => {
+    const allZeroRows = [
+      { position: 0, series: 'A', value: 10 },
+      { position: 0, series: 'B', value: 5 },
+      { position: 1, series: 'A', value: 0 },
+      { position: 1, series: 'B', value: 0 },
+    ] as const
+    const extents = stackExtents(
+      allZeroRows.map((row, index) => ({ index, ...row })),
+      { order: ['A', 'B'] },
+    )
+
+    expectExtent(extents, 2, 0, 0)
+    expectExtent(extents, 3, 0, 0)
+  })
+
+  it('shares the zero-aware diverging policy with materialized vertical and horizontal rows', () => {
+    const positiveRows = [
+      { position: 0, series: 'A', value: 10 },
+      { position: 0, series: 'B', value: 5 },
+      { position: 1, series: 'A', value: 10 },
+      { position: 1, series: 'B', value: 0 },
+    ] as const
+    const options = { order: ['A', 'B'] as const }
+    const vertical = stackRowsY(positiveRows, {
+      x: 'position',
+      y: 'value',
+      z: 'series',
+      ...options,
+    })
+    const horizontal = stackRowsX(positiveRows, {
+      x: 'value',
+      y: 'position',
+      z: 'series',
+      ...options,
+    })
+
+    expect(horizontal).toHaveLength(vertical.length)
+    vertical.forEach((datum, index) => {
+      const transposed = horizontal[index]!
+      expect(transposed.x1).toBeCloseTo(datum.y1)
+      expect(transposed.x2).toBeCloseTo(datum.y2)
+    })
+    expect(vertical[3]!.y1).toBeCloseTo(10)
+    expect(vertical[3]!.y2).toBeCloseTo(10)
+  })
+})
+
 function expectExtent(
   extents: ReturnType<typeof stackExtents>,
   index: number,

--- a/packages/charts-core/src/stack-internal.ts
+++ b/packages/charts-core/src/stack-internal.ts
@@ -1,6 +1,5 @@
 import {
   stack as d3Stack,
-  stackOffsetDiverging,
   stackOffsetExpand,
   stackOffsetNone,
   stackOffsetSilhouette,
@@ -81,7 +80,7 @@ export function stackExtents(
         ? stackOffsetSilhouette
         : options.offset === 'wiggle'
           ? stackOffsetWiggle
-          : stackOffsetDiverging
+          : stackOffsetDivergingZeroAware
   const generator = d3Stack<Record<string, number>, string>()
     .keys(identities)
     .value((row, key) => row[key] ?? 0)
@@ -109,6 +108,60 @@ export function stackExtents(
     })
   })
   return output
+}
+
+/**
+ * d3's `stackOffsetDiverging` assigns `[0, 0]` to a cell whose value is exactly zero, which
+ * parks it on the axis instead of on its stack's running baseline. That is invisible for bars
+ * but not for area and line marks, whose paths interpolate between adjacent positions: the band
+ * collapses to the axis and back, cutting through the layers below.
+ *
+ * Zero-valued cells here instead keep the baseline of the side their own series occupies, so the
+ * band pinches flat against its neighbours. Non-finite values are left to d3's original branch so
+ * marks still see them as gaps.
+ */
+function stackOffsetDivergingZeroAware(
+  series: Series<any, any>[],
+  order: Iterable<number>,
+): void {
+  const n = series.length
+  if (n === 0) return
+
+  // A zero has no sign of its own, so take the side from the series it belongs to. Only an
+  // exclusively negative series stacks downward; positive, mixed and all-zero series stack up.
+  const negativeSide = series.map((values) => {
+    let negative = false
+    let positive = false
+    for (const [start, end] of values) {
+      const dy = end - start
+      if (dy < 0) negative = true
+      else if (dy > 0) positive = true
+    }
+    return negative && !positive
+  })
+
+  const indices = [...order]
+  const m = series[indices[0]!]!.length
+  for (let j = 0; j < m; j += 1) {
+    let yp = 0
+    let yn = 0
+    for (const i of indices) {
+      const d = series[i]![j]!
+      const dy = d[1] - d[0]
+      if (dy > 0) {
+        d[0] = yp
+        d[1] = yp += dy
+      } else if (dy < 0) {
+        d[1] = yn
+        d[0] = yn += dy
+      } else if (dy === 0) {
+        d[0] = d[1] = negativeSide[i] ? yn : yp
+      } else {
+        d[0] = 0
+        d[1] = dy // non-finite, preserved as in d3
+      }
+    }
+  }
 }
 
 function resolveAnchorFraction(options: Readonly<StackOptions>) {


### PR DESCRIPTION
**Problem**

A stacked `areaY`/`areaX`/`barY` with an exact-zero value renders a spike to the axis instead of a flat segment at the current baseline.

`stackExtents` defaults to d3's `stackOffsetDiverging`, which assigns the extent `[0, 0]` to any cell whose value is exactly `0`. d3 does this on purpose — zero has no side, so it is stacked at zero — and for bar marks that is fine, since a zero-height band is invisible wherever it sits. Area and line marks interpolate between adjacent positions, so the same rule makes the band's edges collapse to the axis and return, cutting through every band below it.

<img width="860" height="520" alt="before-buggy" src="https://github.com/user-attachments/assets/2975dc20-74b7-45fe-952f-0b03180d37ce" />

Shows a stacked areaY with two series ("Allowed" climbing, "Creating" idle at 0 for one stage); the "Creating" band spikes to the axis and cuts through "Allowed" underneath.

The bug is not confined to the topmost series. It affects any series that is not the first on its side of the axis, in both directions:

| stack (order A → B) | position with the zero | current | expected |
| --- | --- | --- | --- |
| `A=10, B=5 / A=10, B=0` | `B` | `[0, 0]` | `[10, 10]` |
| `A=-10, B=-5 / A=-10, B=0` | `B` | `[0, 0]` | `[-10, -10]` |
| `A=10, B=-5, C=3 / …, C=0` | `C` | `[0, 0]` | `[10, 10]` |

Every stack in the library is affected, because `diverging` is the default offset and `stack-internal.ts` backs `area`, `area-x`, `bar` and `transform-stack` alike. Applications currently have to pre-perturb their data with an epsilon to avoid it.

**Fix**

Replace the `stackOffsetDiverging` import with a local offset that keeps d3's positive/negative split but resolves a zero-valued cell to the baseline of whichever side its own series occupies, rather than to the axis. A series is treated as negative-side only when it is exclusively negative; anything else (positive, mixed, all-zero) resolves to the positive baseline, which matches [Observable Plot's stack transform](https://github.com/observablehq/plot/blob/main/src/transforms/stack.js) (`else if (y >= 0) yp = Y2[i] = (Y1[i] = yp) + y`).

`stackOffsetExpand`, `stackOffsetSilhouette` and `stackOffsetWiggle` all delegate to `stackOffsetNone`, which accumulates zeros correctly, so they need no change.

<img width="860" height="520" alt="after-fixed" src="https://github.com/user-attachments/assets/eab3a0c6-1220-4ea6-b18c-9eed644c80ec" />

Same dataset as above, after the fix: the "Creating" band pinches flat against "Allowed" at the boundary instead of diving to the axis.

**Behaviour change**

Only cells whose value is exactly `0` move, and only when the running baseline on their side is already nonzero. Verified unchanged:

- a zero in the first series on its side (baseline is already `0`)
- a position where every series is zero
- mixed diverging stacks where the zero series is the only negative one
- non-finite values (`NaN` extents preserved, so gaps still render as gaps)

No public API, type, or option changes. `StackOffset` keeps its four documented values.

**Tests**

Added to `packages/charts-core/src/stack-internal.test.ts`:

- zero in a positive stack keeps the running top (`[10, 10]`, not `[0, 0]`)
- zero in an exclusively-negative stack keeps the running bottom (`[-10, -10]`)
- zero in a mixed diverging stack is unchanged
- an all-zero position is unchanged
- `stackRowsX` / `stackRowsY` agree with `stackExtents` on the above

**Changeset**

`patch` for `@tanstack/charts` (fixed release group covers all adapters).

**Alternative considered**

Selecting `stackOffsetNone` whenever the data contains no negative values is a two-line change and fixes the reported case, but leaves the negative-side and mixed-stack variants of the same bug in place. Not worth splitting into two fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stacked charts so zero-valued cells remain on the correct running baseline when using diverging stacking.
  * Prevented stacked-area segments from incorrectly spiking to the axis.
  * Preserved consistent geometry for both vertical and horizontal stacked charts, including mixed positive and negative values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->