### PR TITLE
Fix catalog interactive data module

### DIFF
--- a/API-FRICTION.md
+++ b/API-FRICTION.md
@@ -322,6 +322,7 @@ Each entry records:
 | F-283 | Interactive chart shells rendered inert controls               | Application           | resolved   |
 | F-284 | Stagger timing required repeated callback arithmetic           | API                   | resolved   |
 | F-285 | Absolute catalog links lost their docs navigation tab          | Documentation         | resolved   |
+| F-286 | Browser imports treated raw JSON as a source module            | Tooling               | resolved   |
 
 ## Findings
 
@@ -8261,3 +8262,22 @@ Each entry records:
   on path inference for a non-docs route.
 - Verification: the local tanstack.com collection route renders the
   `shadcn/ui Charts` sidebar item as active under Examples.
+
+### F-286 — Browser imports treated raw JSON as a source module
+
+- Status: resolved
+- Severity: high
+- Owner: Tooling
+- Observed in: opening the published ShadCN area-interactive catalog example
+- Friction: the example imported an extensionless JSON fixture through the
+  catalog's revision-pinned esm.sh source prefix. esm.sh returned 404 because
+  raw JSON was not a resolvable JavaScript entry, leaving the sandbox root
+  empty while its status remained Running. The same fixture affected the area,
+  bar, and line interactive examples.
+- Decision: expose the fixture as a TypeScript module and validate every
+  catalog demo-data import against a browser-loadable JavaScript or TypeScript
+  source module. JSON and declaration-only files no longer satisfy the public
+  example contract.
+- Verification: the catalog contract validates all example imports, and the
+  revision-pinned esm.sh URL for the fixture returns a JavaScript module that
+  renders the production sandbox.

--- a/benchmarks/conformance/previews/manifest.json
+++ b/benchmarks/conformance/previews/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "width": 288,
   "height": 192,
-  "sourceHash": "f6e45af3af0d44a468e0a33b1bda18065ae1fbd1e3a675778f6586ef426fcb9c",
+  "sourceHash": "c11021e138ff78d85026f99d2da56bf021ab198faa8db0a4844ea6b1028ae87f",
   "assets": [
     {
       "id": "01-line-gaps",

--- a/packages/charts-demo-data/package.json
+++ b/packages/charts-demo-data/package.json
@@ -110,7 +110,8 @@
       "default": "./src/shadcn.ts"
     },
     "./shadcn-area-interactive-data": {
-      "default": "./src/shadcn-area-interactive-data.json"
+      "types": "./src/shadcn-area-interactive-data.ts",
+      "default": "./src/shadcn-area-interactive-data.ts"
     },
     "./survey": {
       "types": "./src/survey.d.ts",

--- a/packages/charts-demo-data/src/shadcn-area-interactive-data.ts
+++ b/packages/charts-demo-data/src/shadcn-area-interactive-data.ts
@@ -1,4 +1,4 @@
-[
+const interactiveAreaData = [
   {
     "date": "2024-04-01",
     "desktop": 222,
@@ -454,4 +454,6 @@
     "desktop": 446,
     "mobile": 400
   }
-]
+] as const
+
+export default interactiveAreaData

--- a/scripts/check-catalog-examples.mjs
+++ b/scripts/check-catalog-examples.mjs
@@ -5,7 +5,10 @@ import ts from 'typescript'
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const casesRoot = path.join(root, 'benchmarks', 'conformance', 'cases')
+const demoDataRoot = path.join(root, 'packages', 'charts-demo-data', 'src')
 const sourceExtensions = ['.ts', '.tsx', '.js', '.jsx', '.json', '.css']
+const browserModuleExtensions = ['.ts', '.tsx', '.js', '.jsx', '.mjs']
+const demoDataPrefixes = ['@charts-poc/demo-data/', '@tanstack/charts-data/']
 const forbiddenPublicNames =
   /\b(?:Conformance|tanstackCase|tanstackMount|reactMount|catalogPreviewDefinition)\b/
 
@@ -69,6 +72,23 @@ for (const directory of directories) {
     }
 
     for (const specifier of importSpecifiers(source, sourcePath)) {
+      const demoDataPrefix = demoDataPrefixes.find((prefix) =>
+        specifier.startsWith(prefix),
+      )
+      if (demoDataPrefix) {
+        const demoDataSpecifier = specifier.slice(demoDataPrefix.length)
+        const resolved = await resolveImport(
+          demoDataRoot,
+          `./${demoDataSpecifier}`,
+          browserModuleExtensions,
+        )
+        if (!resolved) {
+          failures.push(
+            `${directory}/${relativePath}: demo-data import is not a browser module (${specifier})`,
+          )
+        }
+        continue
+      }
       if (!specifier.startsWith('.')) continue
       const resolved = await resolveImport(path.dirname(sourcePath), specifier)
       if (!resolved) {
@@ -190,13 +210,13 @@ function importSpecifiers(source, sourcePath) {
   return specifiers
 }
 
-async function resolveImport(parent, specifier) {
+async function resolveImport(parent, specifier, extensions = sourceExtensions) {
   const target = path.resolve(parent, specifier)
   const candidates = path.extname(target)
     ? [target]
     : [
-        ...sourceExtensions.map((extension) => `${target}${extension}`),
-        ...sourceExtensions.map((extension) =>
+        ...extensions.map((extension) => `${target}${extension}`),
+        ...extensions.map((extension) =>
           path.join(target, `index${extension}`),
         ),
       ]


### PR DESCRIPTION
## What changed

- expose the shared ShadCN interactive dataset as a TypeScript module instead of raw JSON
- update the demo-data package export
- make the catalog contract reject demo-data imports that do not resolve to a browser-loadable source module

## Root cause

The published sandbox maps demo-data imports to revision-pinned esm.sh source URLs. The extensionless interactive-data import resolved only to a `.json` file, so esm.sh returned 404 and the iframe remained blank. This affected the ShadCN area, bar, and line interactive examples.

## Verification

- `pnpm demo-data:check`
- `pnpm catalog:examples:check`
- `pnpm shadcn:catalog:check`
- `pnpm typecheck`
- catalog source tests: 11 passing
- exact pushed revision returns JavaScript from esm.sh for `shadcn-area-interactive-data`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed browser-loading failures affecting the interactive area chart demo.
  * Demo data now loads through browser-compatible TypeScript modules instead of raw JSON imports.
  * Improved example validation to identify unsupported or unresolved demo-data sources.

* **Documentation**
  * Documented the resolved browser-loading issue and clarified requirements for example data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->