### PR TITLE
Improve/align react docs language

### DIFF
--- a/docs/framework/react/quick-start.md
+++ b/docs/framework/react/quick-start.md
@@ -153,8 +153,8 @@ export function LiveLetterFrequency({ rows, accent }: LetterFrequencyInput) {
 }
 ```
 
-The dependency list owns application invalidation. The definition identity
-tells the chart host when captured values changed. See
+TanStack Charts owns rebuilding the chart when its definition changes. The
+application owns when that definition changes through the dependency list. See
 [Chart Definition API](../../reference/chart-definitions.md).
 
 ## Interaction callbacks


### PR DESCRIPTION
Align react docs language to be similar to homepage "what does TanStack own"

https://tanstack.com/charts/latest/docs/overview#what-tanstack-charts-owns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified memoization guidance for TanStack Charts.
  * Explained that charts rebuild when the chart definition changes, based on the application’s dependency list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->