### PR TITLE
Highlight active series in grouped tooltips

### DIFF
--- a/.changeset/active-tooltip-series.md
+++ b/.changeset/active-tooltip-series.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/charts': patch
+---
+
+Highlight the active series in grouped tooltips. Custom tooltip content can use `context.primaryPoint` and `row.active` to show the same highlight when series colors repeat.

--- a/API-FRICTION.md
+++ b/API-FRICTION.md
@@ -331,6 +331,7 @@ Each entry records:
 | F-292 | Fixed preview paints ignored the selected site theme           | Tooling               | resolved   |
 | F-293 | Root scale slots blocked named axes                            | API                   | resolved   |
 | F-294 | Automatic mark renderers imposed shared host plumbing          | API                   | resolved   |
+| F-295 | Grouped tooltips did not identify the active series            | API                   | resolved   |
 
 ## Findings
 
@@ -8505,3 +8506,21 @@ Each entry records:
   React Native Metro gates, and framework package checks pass. Bundle boundary
   checks keep SVG-only entries free of Canvas and measure the opt-in mixed
   representative and React consumers at 35.68 KiB and 41.63 KiB gzip.
+
+### F-295 - Grouped tooltips did not identify the active series
+
+- Status: resolved
+- Severity: medium
+- Owner: API
+- Observed in: NPM stats tooltip review with repeated series colors
+- Friction: Stats overrode the existing visual sort with color-domain order.
+  Removing that application override fixes ordering, but custom tooltip
+  callbacks could not identify the primary point and structured rows had no
+  active style. Repeated colors made the hovered series ambiguous.
+- Decision: expose `context.primaryPoint` and `row.active`, highlight the
+  primary row in default grouped content, and refresh custom bodies when the
+  primary point changes within the same focus group. All framework body
+  renderers preserve this state and DOM defaults use CSS-variable styling.
+- Verification: runtime regressions cover moving between same-colored series
+  with built-in and custom content while preserving visual order. Existing
+  x- and y-grouped ordering tests pass.

--- a/benchmarks/comparison/bundle-baseline.json
+++ b/benchmarks/comparison/bundle-baseline.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 4,
-  "generatedAt": "2026-08-26T21:51:12.832Z",
+  "generatedAt": "2026-09-08T22:11:29.376Z",
   "packageVersions": {
-    "tanstack": "0.15.0",
+    "tanstack": "0.16.0",
     "chartjs": "4.5.1",
     "echarts": "6.1.0",
     "recharts": "3.10.1",
@@ -12,7 +12,7 @@
     "tanstack": {
       "kind": "workspace",
       "revision": "3df87d71f0305e5a450c10b66940f76f3e14259a",
-      "inputDigest": "sha256:b1016e599e63d05e1647b9d27adabaaed7a38bb44dac8d6ba0fef06b8b8bd38e"
+      "inputDigest": "sha256:40278798ed7b78aa3777062fc6ff810a50244823da5e49d9700eeef8b536994f"
     },
     "chartjs": {
       "kind": "package",
@@ -45,88 +45,88 @@
   },
   "bundles": {
     "tanstack-line-basic": {
-      "minifiedBytes": 110431,
-      "gzipBytes": 39891,
-      "brotliBytes": 35325,
-      "incrementalGzipBytes": 39891,
-      "incrementalBrotliBytes": 35325
+      "minifiedBytes": 110996,
+      "gzipBytes": 40024,
+      "brotliBytes": 35426,
+      "incrementalGzipBytes": 40024,
+      "incrementalBrotliBytes": 35426
     },
     "tanstack-line-interactive": {
-      "minifiedBytes": 115872,
-      "gzipBytes": 41648,
-      "brotliBytes": 36746,
-      "incrementalGzipBytes": 41648,
-      "incrementalBrotliBytes": 36746
+      "minifiedBytes": 116437,
+      "gzipBytes": 41782,
+      "brotliBytes": 36848,
+      "incrementalGzipBytes": 41782,
+      "incrementalBrotliBytes": 36848
     },
     "tanstack-line-advanced": {
-      "minifiedBytes": 123062,
-      "gzipBytes": 43974,
-      "brotliBytes": 38764,
-      "incrementalGzipBytes": 43974,
-      "incrementalBrotliBytes": 38764
+      "minifiedBytes": 123627,
+      "gzipBytes": 44128,
+      "brotliBytes": 38892,
+      "incrementalGzipBytes": 44128,
+      "incrementalBrotliBytes": 38892
     },
     "tanstack-bar-basic": {
-      "minifiedBytes": 119225,
-      "gzipBytes": 43210,
-      "brotliBytes": 38168,
-      "incrementalGzipBytes": 43210,
-      "incrementalBrotliBytes": 38168
+      "minifiedBytes": 119790,
+      "gzipBytes": 43347,
+      "brotliBytes": 38287,
+      "incrementalGzipBytes": 43347,
+      "incrementalBrotliBytes": 38287
     },
     "tanstack-bar-interactive": {
-      "minifiedBytes": 123521,
-      "gzipBytes": 44585,
-      "brotliBytes": 39223,
-      "incrementalGzipBytes": 44585,
-      "incrementalBrotliBytes": 39223
+      "minifiedBytes": 124086,
+      "gzipBytes": 44720,
+      "brotliBytes": 39309,
+      "incrementalGzipBytes": 44720,
+      "incrementalBrotliBytes": 39309
     },
     "tanstack-bar-advanced": {
-      "minifiedBytes": 123860,
-      "gzipBytes": 44735,
-      "brotliBytes": 39349,
-      "incrementalGzipBytes": 44735,
-      "incrementalBrotliBytes": 39349
+      "minifiedBytes": 124425,
+      "gzipBytes": 44868,
+      "brotliBytes": 39495,
+      "incrementalGzipBytes": 44868,
+      "incrementalBrotliBytes": 39495
     },
     "tanstack-area-basic": {
-      "minifiedBytes": 115640,
-      "gzipBytes": 41867,
-      "brotliBytes": 37073,
-      "incrementalGzipBytes": 41867,
-      "incrementalBrotliBytes": 37073
+      "minifiedBytes": 116205,
+      "gzipBytes": 42004,
+      "brotliBytes": 37190,
+      "incrementalGzipBytes": 42004,
+      "incrementalBrotliBytes": 37190
     },
     "tanstack-area-interactive": {
-      "minifiedBytes": 121085,
-      "gzipBytes": 43594,
-      "brotliBytes": 38493,
-      "incrementalGzipBytes": 43594,
-      "incrementalBrotliBytes": 38493
+      "minifiedBytes": 121650,
+      "gzipBytes": 43727,
+      "brotliBytes": 38578,
+      "incrementalGzipBytes": 43727,
+      "incrementalBrotliBytes": 38578
     },
     "tanstack-area-advanced": {
-      "minifiedBytes": 128457,
-      "gzipBytes": 46057,
-      "brotliBytes": 40527,
-      "incrementalGzipBytes": 46057,
-      "incrementalBrotliBytes": 40527
+      "minifiedBytes": 129022,
+      "gzipBytes": 46195,
+      "brotliBytes": 40688,
+      "incrementalGzipBytes": 46195,
+      "incrementalBrotliBytes": 40688
     },
     "tanstack-scatter-basic": {
-      "minifiedBytes": 111460,
-      "gzipBytes": 40266,
-      "brotliBytes": 35596,
-      "incrementalGzipBytes": 40266,
-      "incrementalBrotliBytes": 35596
+      "minifiedBytes": 112025,
+      "gzipBytes": 40405,
+      "brotliBytes": 35796,
+      "incrementalGzipBytes": 40405,
+      "incrementalBrotliBytes": 35796
     },
     "tanstack-scatter-interactive": {
-      "minifiedBytes": 116901,
-      "gzipBytes": 42015,
-      "brotliBytes": 36976,
-      "incrementalGzipBytes": 42015,
-      "incrementalBrotliBytes": 36976
+      "minifiedBytes": 117466,
+      "gzipBytes": 42150,
+      "brotliBytes": 37148,
+      "incrementalGzipBytes": 42150,
+      "incrementalBrotliBytes": 37148
     },
     "tanstack-scatter-advanced": {
-      "minifiedBytes": 116917,
-      "gzipBytes": 42020,
-      "brotliBytes": 37012,
-      "incrementalGzipBytes": 42020,
-      "incrementalBrotliBytes": 37012
+      "minifiedBytes": 117482,
+      "gzipBytes": 42155,
+      "brotliBytes": 37106,
+      "incrementalGzipBytes": 42155,
+      "incrementalBrotliBytes": 37106
     },
     "chartjs-line-basic": {
       "minifiedBytes": 137909,

--- a/benchmarks/conformance/previews/manifest.json
+++ b/benchmarks/conformance/previews/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "width": 288,
   "height": 192,
-  "sourceHash": "d3177faf65fca2414b431c195a003cf9afdceb8ae2f1b37e4f8cb81578dc8293",
+  "sourceHash": "ca812a14160bf95e625c3d4a98387baa9e103a4086af3a29a0d9a590a672f05b",
   "assets": [
     {
       "id": "01-line-gaps",

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -90,7 +90,7 @@ output model.
 
 ## Bundle snapshot
 
-Baseline date: `2026-08-26`.
+Baseline date: `2026-09-08`.
 
 Controlled ranges cover 12 independently built, minified browser consumers:
 line, bar, area, and scatter at basic, interactive, and advanced tiers. Only
@@ -106,7 +106,7 @@ Vega-Lite, AG Charts, and uPlot main exports were read from Bundlephobia on July
 
 | Library            | Bundle size                            | React externalized | Evidence                                                   |
 | ------------------ | -------------------------------------- | -----------------: | ---------------------------------------------------------- |
-| TanStack Charts    | 38.96–44.98 KiB                        |     Not applicable | Controlled suite                                           |
+| TanStack Charts    | 39.09–45.11 KiB                        |     Not applicable | Controlled suite                                           |
 | D3                 | 90 KB gzip                             |                  — | External main export                                       |
 | Chart.js           | 44.70–58.21 KiB                        |                  — | Controlled suite                                           |
 | Apache ECharts     | 153.10–173.18 KiB                      |                  — | Controlled suite                                           |

--- a/docs/guides/tooltips-and-focus.md
+++ b/docs/guides/tooltips-and-focus.md
@@ -670,3 +670,44 @@ search over every raw point.
 - Keep interactive content pinned and dismissible.
 - Let framework lifecycle destroy nested charts and external listeners with
   their owner.
+
+### Active series
+
+Grouped tooltip rows follow their chart positions by default: top to bottom
+for x focus, and left to right for y focus. The primary hovered or
+keyboard-focused point gets a bold row with a shaded background in DOM tooltips, even when
+several series share a color.
+
+For custom structured content, set each row's `active` field by comparing its
+point with `context.primaryPoint`:
+
+```ts
+content: (points, context) => ({
+  rows: points.map((point) => ({
+    label: point.groupLabel,
+    value: context.formatY(point.yValue),
+    color: point.color,
+    active: point === context.primaryPoint,
+  })),
+})
+```
+
+Rows expose `data-active="true"` or `data-active="false"` for custom styling.
+
+The default emphasis uses CSS variables, so you can restyle it without
+replacing the tooltip body. Set `tooltip.className` to scope the overrides:
+
+```css
+.downloads-tooltip {
+  --ts-chart-tooltip-active-row-font-weight: 600;
+  --ts-chart-tooltip-active-row-background: transparent;
+  --ts-chart-tooltip-active-row-border-radius: 0;
+  --ts-chart-tooltip-active-row-shadow: none;
+}
+```
+
+Set `active: false` in custom structured content to disable the highlight.
+For complete control over markup and styling, use your adapter's tooltip-body
+composition surface. Structured `content.rows` retain their `active` state
+for your renderer to use. Body render callbacks also receive `primaryPoint`,
+independent of the sorted `points` list.

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -350,8 +350,8 @@ See [DOM host](./dom-host.md) and
 | `ChartDefinitionOptions`              | Focus, selection, controls, cursor, tooltip, and host interaction policy |
 | `ResponsiveChartConfig`               | Responsive builder plus definition-owned interaction policy              |
 | `ChartTooltipContent`                 | Safe title and row model for a built-in tooltip                          |
-| `ChartTooltipRow`                     | Label, formatted value, and optional color swatch                        |
-| `ChartTooltipContentContext`          | Pinned state, axis labels, and value formatters for tooltip callbacks    |
+| `ChartTooltipRow`                     | Label, formatted value, optional color swatch, and active state          |
+| `ChartTooltipContentContext`          | Primary point, pinned state, axis labels, and value formatters           |
 | `ChartTooltipBodyContext`             | Focused points, content, pinned state, and dismissal                     |
 | `ChartTooltipBodyTarget`              | Renderer-adapter body mount element plus body context                    |
 | `TooltipBounds`                       | Host-local tooltip placement boundary                                    |

--- a/packages/alpine-charts/src/index.ts
+++ b/packages/alpine-charts/src/index.ts
@@ -172,6 +172,7 @@ function createTooltipBodyChangeHandler<
       target.content,
     )
     const content = renderTooltipBody({
+      primaryPoint: target.primaryPoint,
       points: target.points,
       content: target.content,
       defaultBody,
@@ -227,6 +228,17 @@ function createDefaultTooltipBody(
       line.className = 'ts-chart-tooltip__row'
       line.style.cssText =
         'display:grid;grid-template-columns:.55rem minmax(0,1fr) auto;align-items:center;column-gap:.4rem'
+      line.dataset.active = String(row.active === true)
+      if (row.active) {
+        line.style.fontWeight =
+          'var(--ts-chart-tooltip-active-row-font-weight, 700)'
+        line.style.background =
+          'var(--ts-chart-tooltip-active-row-background, color-mix(in srgb, currentColor 12%, transparent))'
+        line.style.borderRadius =
+          'var(--ts-chart-tooltip-active-row-border-radius, .2rem)'
+        line.style.boxShadow =
+          'var(--ts-chart-tooltip-active-row-shadow, 0 0 0 2px color-mix(in srgb, currentColor 12%, transparent))'
+      }
       const swatch = row.color
         ? createTooltipSwatch(document, row.color)
         : document.createElement('span')

--- a/packages/angular-charts/src/Chart.ts
+++ b/packages/angular-charts/src/Chart.ts
@@ -93,6 +93,27 @@ class ChartIdGenerator {
             @for (row of content.rows; track $index) {
               <div
                 class="ts-chart-tooltip__row"
+                [attr.data-active]="row.active === true"
+                [style.fontWeight]="
+                  row.active
+                    ? 'var(--ts-chart-tooltip-active-row-font-weight, 700)'
+                    : null
+                "
+                [style.background]="
+                  row.active
+                    ? 'var(--ts-chart-tooltip-active-row-background, color-mix(in srgb, currentColor 12%, transparent))'
+                    : null
+                "
+                [style.borderRadius]="
+                  row.active
+                    ? 'var(--ts-chart-tooltip-active-row-border-radius, .2rem)'
+                    : null
+                "
+                [style.boxShadow]="
+                  row.active
+                    ? 'var(--ts-chart-tooltip-active-row-shadow, 0 0 0 2px color-mix(in srgb, currentColor 12%, transparent))'
+                    : null
+                "
                 style="display:grid;grid-template-columns:0.55rem minmax(0,1fr) auto;align-items:center;column-gap:0.4rem"
               >
                 @if (row.color) {
@@ -268,6 +289,7 @@ export class Chart<
     }
 
     const nextContext = {
+      primaryPoint: target.primaryPoint,
       points: target.points,
       content: target.content,
       defaultBody: this.defaultTooltipBody,

--- a/packages/charts-core/docs/comparison.md
+++ b/packages/charts-core/docs/comparison.md
@@ -90,7 +90,7 @@ output model.
 
 ## Bundle snapshot
 
-Baseline date: `2026-08-26`.
+Baseline date: `2026-09-08`.
 
 Controlled ranges cover 12 independently built, minified browser consumers:
 line, bar, area, and scatter at basic, interactive, and advanced tiers. Only
@@ -106,7 +106,7 @@ Vega-Lite, AG Charts, and uPlot main exports were read from Bundlephobia on July
 
 | Library            | Bundle size                            | React externalized | Evidence                                                   |
 | ------------------ | -------------------------------------- | -----------------: | ---------------------------------------------------------- |
-| TanStack Charts    | 38.96–44.98 KiB                        |     Not applicable | Controlled suite                                           |
+| TanStack Charts    | 39.09–45.11 KiB                        |     Not applicable | Controlled suite                                           |
 | D3                 | 90 KB gzip                             |                  — | External main export                                       |
 | Chart.js           | 44.70–58.21 KiB                        |                  — | Controlled suite                                           |
 | Apache ECharts     | 153.10–173.18 KiB                      |                  — | Controlled suite                                           |

--- a/packages/charts-core/docs/guides/tooltips-and-focus.md
+++ b/packages/charts-core/docs/guides/tooltips-and-focus.md
@@ -670,3 +670,44 @@ search over every raw point.
 - Keep interactive content pinned and dismissible.
 - Let framework lifecycle destroy nested charts and external listeners with
   their owner.
+
+### Active series
+
+Grouped tooltip rows follow their chart positions by default: top to bottom
+for x focus, and left to right for y focus. The primary hovered or
+keyboard-focused point gets a bold row with a shaded background in DOM tooltips, even when
+several series share a color.
+
+For custom structured content, set each row's `active` field by comparing its
+point with `context.primaryPoint`:
+
+```ts
+content: (points, context) => ({
+  rows: points.map((point) => ({
+    label: point.groupLabel,
+    value: context.formatY(point.yValue),
+    color: point.color,
+    active: point === context.primaryPoint,
+  })),
+})
+```
+
+Rows expose `data-active="true"` or `data-active="false"` for custom styling.
+
+The default emphasis uses CSS variables, so you can restyle it without
+replacing the tooltip body. Set `tooltip.className` to scope the overrides:
+
+```css
+.downloads-tooltip {
+  --ts-chart-tooltip-active-row-font-weight: 600;
+  --ts-chart-tooltip-active-row-background: transparent;
+  --ts-chart-tooltip-active-row-border-radius: 0;
+  --ts-chart-tooltip-active-row-shadow: none;
+}
+```
+
+Set `active: false` in custom structured content to disable the highlight.
+For complete control over markup and styling, use your adapter's tooltip-body
+composition surface. Structured `content.rows` retain their `active` state
+for your renderer to use. Body render callbacks also receive `primaryPoint`,
+independent of the sorted `points` list.

--- a/packages/charts-core/docs/reference/types.md
+++ b/packages/charts-core/docs/reference/types.md
@@ -350,8 +350,8 @@ See [DOM host](./dom-host.md) and
 | `ChartDefinitionOptions`              | Focus, selection, controls, cursor, tooltip, and host interaction policy |
 | `ResponsiveChartConfig`               | Responsive builder plus definition-owned interaction policy              |
 | `ChartTooltipContent`                 | Safe title and row model for a built-in tooltip                          |
-| `ChartTooltipRow`                     | Label, formatted value, and optional color swatch                        |
-| `ChartTooltipContentContext`          | Pinned state, axis labels, and value formatters for tooltip callbacks    |
+| `ChartTooltipRow`                     | Label, formatted value, optional color swatch, and active state          |
+| `ChartTooltipContentContext`          | Primary point, pinned state, axis labels, and value formatters           |
 | `ChartTooltipBodyContext`             | Focused points, content, pinned state, and dismissal                     |
 | `ChartTooltipBodyTarget`              | Renderer-adapter body mount element plus body context                    |
 | `TooltipBounds`                       | Host-local tooltip placement boundary                                    |

--- a/packages/charts-core/src/runtime.test.ts
+++ b/packages/charts-core/src/runtime.test.ts
@@ -737,6 +737,7 @@ describe('dynamic chart runtime', () => {
     expect(rows?.[0]?.textContent).toContain('12')
     expect(rows?.[1]?.textContent).toContain('Query')
     expect(rows?.[1]?.textContent).toContain('8')
+    expect(tooltip?.querySelectorAll('[data-active="true"]')).toHaveLength(1)
     expect(tooltip?.querySelectorAll('.ts-chart-tooltip__swatch')).toHaveLength(
       2,
     )
@@ -789,8 +790,87 @@ describe('dynamic chart runtime', () => {
     expect(rows[0]?.textContent).toContain('4')
     expect(rows[1]?.textContent).toContain('Long')
     expect(rows[1]?.textContent).toContain('12')
+    expect(container.querySelectorAll('[data-active="true"]')).toHaveLength(1)
     host.destroy()
   })
+
+  it.each([false, true])(
+    'tracks the active series with repeated colors (custom: %s)',
+    (custom) => {
+      const container = document.createElement('div')
+      const host = mountChart(container, {
+        definition: defineChart({
+          marks: [
+            lineY(
+              [
+                { id: 'low', x: 1, y: 4, series: 'Low' },
+                { id: 'high', x: 1, y: 8, series: 'High' },
+              ],
+              { x: 'x', y: 'y', z: 'series', key: 'id', stroke: '#336699' },
+            ),
+          ],
+          ...linearAxes([0, 2], [0, 10]),
+          focus: 'group-x',
+          tooltip: {
+            use: tooltipExtension,
+            ...(custom
+              ? {
+                  content: (
+                    points: readonly ChartPoint[],
+                    context: ChartTooltipContentContext,
+                  ) => ({
+                    rows: points.map((point) => ({
+                      label: point.groupLabel,
+                      value: String(point.yValue),
+                      color: point.color,
+                      active: point === context.primaryPoint,
+                    })),
+                  }),
+                }
+              : {}),
+          },
+        }),
+        width: 480,
+        height: 260,
+        ariaLabel: 'Repeated series colors',
+      })
+      const svg = container.querySelector('svg')
+      if (!svg) throw new Error('Expected SVG')
+      vi.spyOn(svg, 'getBoundingClientRect').mockReturnValue({
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: 480,
+        bottom: 260,
+        width: 480,
+        height: 260,
+        toJSON: () => ({}),
+      })
+      for (const point of host.getScene().points) {
+        svg.dispatchEvent(
+          new MouseEvent('pointermove', {
+            bubbles: true,
+            clientX: point.x,
+            clientY: point.y,
+          }),
+        )
+        const active = container.querySelectorAll(
+          '.ts-chart-tooltip__row[data-active="true"]',
+        )
+        expect(active).toHaveLength(1)
+        expect(active[0]?.textContent).toContain(point.groupLabel)
+        expect(
+          container.querySelector('.ts-chart-tooltip__row')?.textContent,
+        ).toContain('High')
+        expect(
+          container.querySelector<HTMLElement>('[data-active="true"]')?.style
+            .fontWeight,
+        ).toBe('var(--ts-chart-tooltip-active-row-font-weight, 700)')
+      }
+      host.destroy()
+    },
+  )
 
   it('formats interval ranges and stacked lengths automatically', () => {
     const rangeContainer = document.createElement('div')

--- a/packages/charts-core/src/tooltip-model.ts
+++ b/packages/charts-core/src/tooltip-model.ts
@@ -60,7 +60,10 @@ export function createChartTooltipContent<
 ): ChartTooltipContent | string {
   const point = points[0]
   if (!point) return { rows: [] }
-  const context = createTooltipContentContext(scene, pinned, options)
+  const context = {
+    ...createTooltipContentContext(scene, pinned, options),
+    primaryPoint,
+  }
   const content = options?.content?.(points, context)
   if (content !== undefined) return content
   const formatted =
@@ -203,6 +206,7 @@ function defaultTooltipContent(
           context,
         ),
         color: candidate.color,
+        active: candidate === context.primaryPoint,
       })),
     }
   }
@@ -213,6 +217,7 @@ function defaultTooltipContent(
         label: formatTooltipGroup(candidate, group, context),
         value: `${formatPointAxis(candidate, 'x', x, context)} · ${formatPointAxis(candidate, 'y', y, context)}`,
         color: candidate.color,
+        active: candidate === context.primaryPoint,
       })),
     }
   }

--- a/packages/charts-core/src/tooltip.ts
+++ b/packages/charts-core/src/tooltip.ts
@@ -94,6 +94,7 @@ function createTooltipExtension<
   function paint(
     nextContext: ChartTooltipPaintContext<TDatum, TXValue, TYValue>,
   ) {
+    if (paintContext?.point !== nextContext.point) bodyDirty = true
     paintContext = nextContext
     if (options.visibility === 'pinned' && !nextContext.pinned) {
       hide()
@@ -296,6 +297,7 @@ function createTooltipExtension<
     if (changed) {
       callback({
         element: bodyElement,
+        primaryPoint: paintContext?.point,
         points,
         content,
         pinned,
@@ -690,6 +692,17 @@ function paintStructuredTooltip(
       line.className = 'ts-chart-tooltip__row'
       line.style.cssText =
         'display:grid;grid-template-columns:.55rem minmax(0,1fr) auto;align-items:center;column-gap:.4rem'
+      line.dataset.active = String(row.active === true)
+      if (row.active) {
+        line.style.fontWeight =
+          'var(--ts-chart-tooltip-active-row-font-weight, 700)'
+        line.style.background =
+          'var(--ts-chart-tooltip-active-row-background, color-mix(in srgb, currentColor 12%, transparent))'
+        line.style.borderRadius =
+          'var(--ts-chart-tooltip-active-row-border-radius, .2rem)'
+        line.style.boxShadow =
+          'var(--ts-chart-tooltip-active-row-shadow, 0 0 0 2px color-mix(in srgb, currentColor 12%, transparent))'
+      }
       const swatch = row.color
         ? createTooltipSwatch(document, row.color)
         : document.createElement('span')

--- a/packages/charts-core/src/types.ts
+++ b/packages/charts-core/src/types.ts
@@ -1971,6 +1971,8 @@ export interface ChartTooltipContent {
 }
 
 export interface ChartTooltipContentContext {
+  /** The hovered or keyboard-focused point, independent of tooltip row order. */
+  primaryPoint?: ChartPoint
   pinned: boolean
   xLabel: string
   yLabel: string
@@ -1979,6 +1981,8 @@ export interface ChartTooltipContentContext {
 }
 
 export interface ChartTooltipRow {
+  /** Emphasizes this row independently of its series color. */
+  active?: boolean
   label: string
   value: string
   color?: string
@@ -1989,6 +1993,7 @@ export interface ChartTooltipBodyContext<
   TXValue extends ChartValue = ChartValue,
   TYValue extends ChartValue = ChartValue,
 > {
+  primaryPoint?: ChartPoint<TDatum, TXValue, TYValue>
   points: readonly ChartPoint<TDatum, TXValue, TYValue>[]
   content: ChartTooltipContent | string
   pinned: boolean

--- a/packages/lit-charts/src/Chart.ts
+++ b/packages/lit-charts/src/Chart.ts
@@ -162,6 +162,7 @@ export class Chart<
     }
     renderLit(
       renderTooltipBody({
+        primaryPoint: target.primaryPoint,
         points: target.points,
         content: target.content,
         defaultBody: renderDefaultTooltipBody(target.content),
@@ -273,7 +274,8 @@ function renderDefaultTooltipBody(
           (row) =>
             html`<div
               class="ts-chart-tooltip__row"
-              style="display:grid;grid-template-columns:0.55rem minmax(0,1fr) auto;align-items:center;column-gap:0.4rem"
+              data-active=${String(row.active === true)}
+              style="display:grid;grid-template-columns:0.55rem minmax(0,1fr) auto;align-items:center;column-gap:0.4rem;${row.active ? 'font-weight:var(--ts-chart-tooltip-active-row-font-weight, 700);background:var(--ts-chart-tooltip-active-row-background, color-mix(in srgb, currentColor 12%, transparent));border-radius:var(--ts-chart-tooltip-active-row-border-radius, .2rem);box-shadow:var(--ts-chart-tooltip-active-row-shadow, 0 0 0 2px color-mix(in srgb, currentColor 12%, transparent))' : ''}"
             >
               ${
                 row.color ? renderTooltipSwatch(row.color) : html`<span></span>`

--- a/packages/octane-charts/src/RendererChart.tsrx
+++ b/packages/octane-charts/src/RendererChart.tsrx
@@ -128,6 +128,7 @@ export function RendererChart<
     props.renderTooltipBody && tooltipBodyTarget
       ? createPortal(
           props.renderTooltipBody({
+            primaryPoint: tooltipBodyTarget.primaryPoint,
             points: tooltipBodyTarget.points,
             content: tooltipBodyTarget.content,
             pinned: tooltipBodyTarget.pinned,
@@ -191,12 +192,17 @@ function DefaultTooltipBody({
           {content.rows.map((row, index) => (
             <div
               class="ts-chart-tooltip__row"
+              data-active={String(row.active === true)}
               key={`${row.label}\0${index}`}
               style={{
                 display: 'grid',
                 gridTemplateColumns: '0.55rem minmax(0,1fr) auto',
                 alignItems: 'center',
                 columnGap: '0.4rem',
+                fontWeight: row.active ? 'var(--ts-chart-tooltip-active-row-font-weight, 700)' : undefined,
+                background: row.active ? 'var(--ts-chart-tooltip-active-row-background, color-mix(in srgb, currentColor 12%, transparent))' : undefined,
+                borderRadius: row.active ? 'var(--ts-chart-tooltip-active-row-border-radius, .2rem)' : undefined,
+                boxShadow: row.active ? 'var(--ts-chart-tooltip-active-row-shadow, 0 0 0 2px color-mix(in srgb, currentColor 12%, transparent))' : undefined,
               }}
             >
               {row.color ? <TooltipSwatch color={row.color} /> : <span />}

--- a/packages/preact-charts/src/Chart.tsx
+++ b/packages/preact-charts/src/Chart.tsx
@@ -66,6 +66,7 @@ export function Chart<
     props.renderTooltipBody && tooltipBodyTarget
       ? createPortal(
           props.renderTooltipBody({
+            primaryPoint: tooltipBodyTarget.primaryPoint,
             points: tooltipBodyTarget.points,
             content: tooltipBodyTarget.content,
             defaultBody: (
@@ -198,12 +199,25 @@ function DefaultTooltipBody({
           {content.rows.map((row, index) => (
             <div
               className="ts-chart-tooltip__row"
+              data-active={String(row.active === true)}
               key={`${row.label}\0${index}`}
               style={{
                 display: 'grid',
                 gridTemplateColumns: '0.55rem minmax(0,1fr) auto',
                 alignItems: 'center',
                 columnGap: '0.4rem',
+                fontWeight: row.active
+                  ? 'var(--ts-chart-tooltip-active-row-font-weight, 700)'
+                  : undefined,
+                background: row.active
+                  ? 'var(--ts-chart-tooltip-active-row-background, color-mix(in srgb, currentColor 12%, transparent))'
+                  : undefined,
+                borderRadius: row.active
+                  ? 'var(--ts-chart-tooltip-active-row-border-radius, .2rem)'
+                  : undefined,
+                boxShadow: row.active
+                  ? 'var(--ts-chart-tooltip-active-row-shadow, 0 0 0 2px color-mix(in srgb, currentColor 12%, transparent))'
+                  : undefined,
               }}
             >
               {row.color ? <TooltipSwatch color={row.color} /> : <span />}

--- a/packages/react-charts/src/Chart.test.tsx
+++ b/packages/react-charts/src/Chart.test.tsx
@@ -3,7 +3,13 @@ import { act } from 'react'
 import { createRoot, hydrateRoot } from 'react-dom/client'
 import { renderToString } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
-import { areaY, defineChart, dot, lineY } from '@tanstack/charts'
+import {
+  areaY,
+  createChartScene,
+  defineChart,
+  dot,
+  lineY,
+} from '@tanstack/charts'
 import type {
   ChartDefinition,
   ChartInteractionController,
@@ -159,6 +165,7 @@ if (false) {
               title?: string
               color?: string
               rows: readonly {
+                active?: boolean
                 label: string
                 value: string
                 color?: string
@@ -218,6 +225,80 @@ if (false) {
 }
 
 describe('React adapter', () => {
+  it('updates custom tooltip bodies when only the primary series changes', async () => {
+    const definition = defineChart({
+      marks: [
+        lineY(
+          [
+            { x: 1, y: 4, series: 'Low' },
+            { x: 1, y: 8, series: 'High' },
+          ],
+          { x: 'x', y: 'y', z: 'series', stroke: '#336699' },
+        ),
+      ],
+      scales: {
+        x: { scale: scaleLinear().domain([0, 2]) },
+        y: { scale: scaleLinear().domain([0, 10]) },
+      },
+      focus: 'group-x',
+      tooltip: { use: tooltip },
+    })
+    const target = document.createElement('div')
+    document.body.append(target)
+    const root = createRoot(target)
+    await act(async () =>
+      root.render(
+        <TooltipChart
+          definition={definition}
+          width={480}
+          height={260}
+          ariaLabel="Grouped series"
+          renderTooltipBody={({ primaryPoint, defaultBody }) => (
+            <div>
+              {defaultBody}
+              <span data-testid="primary">{primaryPoint?.groupLabel}</span>
+            </div>
+          )}
+        />,
+      ),
+    )
+    const svg = target.querySelector('svg')
+    if (!svg) throw new Error('Expected SVG')
+    vi.spyOn(svg, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 480,
+      bottom: 260,
+      width: 480,
+      height: 260,
+      toJSON: () => ({}),
+    })
+    const scene = createChartScene(definition, { width: 480, height: 260 })
+    for (const point of scene.points) {
+      await act(async () =>
+        svg.dispatchEvent(
+          new MouseEvent('pointermove', {
+            bubbles: true,
+            clientX: point.x,
+            clientY: point.y,
+          }),
+        ),
+      )
+      expect(target.querySelector('[data-testid="primary"]')?.textContent).toBe(
+        point.groupLabel,
+      )
+      const active = target.querySelectorAll(
+        '.ts-chart-tooltip__row[data-active="true"]',
+      )
+      expect(active).toHaveLength(1)
+      expect(active[0]?.textContent).toContain(point.groupLabel)
+    }
+    await act(async () => root.unmount())
+    target.remove()
+  })
+
   it('server-renders the complete shared SVG renderer output', () => {
     const html = renderToString(
       <Chart

--- a/packages/react-charts/src/tooltip.tsx
+++ b/packages/react-charts/src/tooltip.tsx
@@ -164,6 +164,7 @@ function useTooltipBody<
       renderTooltipBody && target
         ? createPortal(
             renderTooltipBody({
+              primaryPoint: target.primaryPoint,
               points: target.points,
               content: target.content,
               pinned: target.pinned,
@@ -205,12 +206,25 @@ function DefaultTooltipBody({
           {content.rows.map((row, index) => (
             <div
               className="ts-chart-tooltip__row"
+              data-active={String(row.active === true)}
               key={`${row.label}\0${index}`}
               style={{
                 display: 'grid',
                 gridTemplateColumns: '0.55rem minmax(0,1fr) auto',
                 alignItems: 'center',
                 columnGap: '0.4rem',
+                fontWeight: row.active
+                  ? 'var(--ts-chart-tooltip-active-row-font-weight, 700)'
+                  : undefined,
+                background: row.active
+                  ? 'var(--ts-chart-tooltip-active-row-background, color-mix(in srgb, currentColor 12%, transparent))'
+                  : undefined,
+                borderRadius: row.active
+                  ? 'var(--ts-chart-tooltip-active-row-border-radius, .2rem)'
+                  : undefined,
+                boxShadow: row.active
+                  ? 'var(--ts-chart-tooltip-active-row-shadow, 0 0 0 2px color-mix(in srgb, currentColor 12%, transparent))'
+                  : undefined,
               }}
             >
               {row.color ? <TooltipSwatch color={row.color} /> : <span />}

--- a/packages/react-native-charts/src/Tooltip.test.ts
+++ b/packages/react-native-charts/src/Tooltip.test.ts
@@ -43,11 +43,19 @@ describe('native tooltip model', () => {
   it('builds the supported shared-axis default content', () => {
     const points = [point('alpha', 'Alpha', 3), point('beta', 'Beta', 7)]
 
-    expect(createNativeTooltipContent(points, scene(points))).toEqual({
+    expect(
+      createNativeTooltipContent(
+        points,
+        scene(points),
+        false,
+        undefined,
+        points[1],
+      ),
+    ).toEqual({
       title: '1',
       rows: [
-        { label: 'Alpha', value: '3', color: '#2563eb' },
-        { label: 'Beta', value: '7', color: '#f97316' },
+        { label: 'Alpha', value: '3', color: '#2563eb', active: false },
+        { label: 'Beta', value: '7', color: '#f97316', active: true },
       ],
     })
   })

--- a/packages/react-native-charts/src/Tooltip.tsx
+++ b/packages/react-native-charts/src/Tooltip.tsx
@@ -30,6 +30,7 @@ export interface NativeChartTooltipRenderContext<
   TXValue extends ChartValue,
   TYValue extends ChartValue,
 > {
+  primaryPoint?: ChartPoint<TDatum, TXValue, TYValue>
   points: readonly ChartPoint<TDatum, TXValue, TYValue>[]
   content: ChartTooltipContent | string
   pinned: boolean
@@ -122,7 +123,14 @@ export function NativeChartTooltip<
     />
   )
   const body = render
-    ? render({ points, content, pinned, dismiss, defaultBody })
+    ? render({
+        primaryPoint: point,
+        points,
+        content,
+        pinned,
+        dismiss,
+        defaultBody,
+      })
     : defaultBody
   const accessibilityLabel = tooltipAccessibilityLabel(content)
   const handleLayout = (event: LayoutChangeEvent) => {
@@ -207,10 +215,24 @@ function DefaultNativeTooltipBody({
               },
             ]}
           />
-          <Text numberOfLines={1} style={rowLabelStyle}>
+          <Text
+            numberOfLines={1}
+            style={
+              row.active
+                ? { ...rowLabelStyle, fontWeight: '700' }
+                : rowLabelStyle
+            }
+          >
             {row.label}
           </Text>
-          <Text numberOfLines={1} style={rowValueStyle}>
+          <Text
+            numberOfLines={1}
+            style={
+              row.active
+                ? { ...rowValueStyle, fontWeight: '700' }
+                : rowValueStyle
+            }
+          >
             {row.value}
           </Text>
         </View>

--- a/packages/solid-charts/src/Chart.tsx
+++ b/packages/solid-charts/src/Chart.tsx
@@ -155,6 +155,9 @@ function TooltipBodyPortal<
 }): JSX.Element {
   const defaultBody = <DefaultTooltipBody content={props.target().content} />
   const context: ChartTooltipBodyRenderContext<TDatum, TXValue, TYValue> = {
+    get primaryPoint() {
+      return props.target().primaryPoint
+    },
     get points() {
       return props.target().points
     },
@@ -218,11 +221,24 @@ function StructuredTooltipBody(props: {
           {props.content.rows.map((row) => (
             <div
               class="ts-chart-tooltip__row"
+              data-active={String(row.active === true)}
               style={{
                 display: 'grid',
                 'grid-template-columns': '0.55rem minmax(0,1fr) auto',
                 'align-items': 'center',
                 'column-gap': '0.4rem',
+                'font-weight': row.active
+                  ? 'var(--ts-chart-tooltip-active-row-font-weight, 700)'
+                  : undefined,
+                background: row.active
+                  ? 'var(--ts-chart-tooltip-active-row-background, color-mix(in srgb, currentColor 12%, transparent))'
+                  : undefined,
+                'border-radius': row.active
+                  ? 'var(--ts-chart-tooltip-active-row-border-radius, .2rem)'
+                  : undefined,
+                'box-shadow': row.active
+                  ? 'var(--ts-chart-tooltip-active-row-shadow, 0 0 0 2px color-mix(in srgb, currentColor 12%, transparent))'
+                  : undefined,
               }}
             >
               {row.color ? <TooltipSwatch color={row.color} /> : <span />}

--- a/packages/svelte-charts/src/Chart.svelte
+++ b/packages/svelte-charts/src/Chart.svelte
@@ -196,10 +196,15 @@
           {#each target.content.rows as row}
             <div
               class="ts-chart-tooltip__row"
+              data-active={String(row.active === true)}
               style:display="grid"
               style:grid-template-columns="0.55rem minmax(0,1fr) auto"
               style:align-items="center"
               style:column-gap="0.4rem"
+              style:font-weight={row.active ? 'var(--ts-chart-tooltip-active-row-font-weight, 700)' : undefined}
+              style:background={row.active ? 'var(--ts-chart-tooltip-active-row-background, color-mix(in srgb, currentColor 12%, transparent))' : undefined}
+              style:border-radius={row.active ? 'var(--ts-chart-tooltip-active-row-border-radius, .2rem)' : undefined}
+              style:box-shadow={row.active ? 'var(--ts-chart-tooltip-active-row-shadow, 0 0 0 2px color-mix(in srgb, currentColor 12%, transparent))' : undefined}
             >
               {#if row.color}
                 {@render tooltipSwatch(row.color)}
@@ -226,6 +231,7 @@
   >
     {@render
       props.tooltipBody({
+        primaryPoint: target.primaryPoint,
         points: target.points,
         content: target.content,
         pinned: target.pinned,

--- a/packages/vue-charts/src/Chart.ts
+++ b/packages/vue-charts/src/Chart.ts
@@ -169,6 +169,7 @@ const ChartImplementation = defineComponent({
               Teleport,
               { to: target.element },
               slots.tooltipBody({
+                primaryPoint: target.primaryPoint,
                 points: target.points,
                 content: target.content,
                 pinned: target.pinned,
@@ -281,11 +282,24 @@ function renderDefaultTooltipBody(
               'div',
               {
                 class: 'ts-chart-tooltip__row',
+                'data-active': String(row.active === true),
                 style: {
                   display: 'grid',
                   gridTemplateColumns: '0.55rem minmax(0,1fr) auto',
                   alignItems: 'center',
                   columnGap: '0.4rem',
+                  fontWeight: row.active
+                    ? 'var(--ts-chart-tooltip-active-row-font-weight, 700)'
+                    : undefined,
+                  background: row.active
+                    ? 'var(--ts-chart-tooltip-active-row-background, color-mix(in srgb, currentColor 12%, transparent))'
+                    : undefined,
+                  borderRadius: row.active
+                    ? 'var(--ts-chart-tooltip-active-row-border-radius, .2rem)'
+                    : undefined,
+                  boxShadow: row.active
+                    ? 'var(--ts-chart-tooltip-active-row-shadow, 0 0 0 2px color-mix(in srgb, currentColor 12%, transparent))'
+                    : undefined,
                 },
               },
               [

--- a/scripts/measure-bundles.mjs
+++ b/scripts/measure-bundles.mjs
@@ -1829,7 +1829,7 @@ const entries = [
   budgeted(
     'Stats parity surface',
     'benchmarks/entries/charts-stats-parity.ts',
-    52.82,
+    53.0,
   ),
   locked(
     'Custom-scale line scene',
@@ -2089,7 +2089,7 @@ const entries = [
   budgeted(
     'React Stats parity surface',
     'benchmarks/entries/charts-react-stats-parity.tsx',
-    53.72,
+    53.9,
     { external: ['react', 'react/jsx-runtime', 'react-dom'] },
   ),
   measured('Plot renderer integration', 'benchmarks/entries/plot-renderer.ts'),


### PR DESCRIPTION
Grouped tooltips now identify the hovered or keyboard-focused series even when several series share a color. The default DOM row uses bold text and a shaded background, with CSS variables for its appearance. Native rows use bold text.

Custom content and framework tooltip-body callbacks receive `primaryPoint`, independent of the sorted point list. Structured rows accept `active`, and custom bodies refresh when the primary point changes within the same focus group. The built-in bodies preserve this state across framework adapters.

Includes a patch changeset, documentation, regression coverage for repeated colors and custom bodies, and refreshed generated catalog and bundle metadata. Verified the default styling and all four CSS overrides in Chromium.

The active-row state and styling add about 0.13 KiB gzip to the controlled interactive chart range. The two Stats-specific budgets are adjusted from 52.82/53.72 KiB to 53.0/53.9 KiB for measured sizes of 52.94/53.83 KiB. Other bundle budgets are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Grouped tooltips now highlight the active series, including when multiple series share the same color.
  - Custom tooltip content can identify the primary focused point and active rows.
  - Active-row styling is available across supported chart frameworks and can be customized with CSS variables or disabled.

- **Documentation**
  - Added guidance and reference details for active tooltip rows, customization, and styling.

- **Tests**
  - Added coverage for active-series tracking in grouped and custom tooltips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->