### PR TITLE
ci: fetch full history before classifying PR changes

### DIFF
--- a/.github/workflows/chart-library-benchmarks.yml
+++ b/.github/workflows/chart-library-benchmarks.yml
@@ -42,7 +42,7 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 2
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Classify pull request changes

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -244,9 +244,14 @@ describe('CI workflow contract', () => {
     })
   })
 
+  test('fetches complete pull request history before classification', () => {
+    const selection = job('changes')
+    assert.match(selection, /fetch-depth:\s*0/)
+    assert.match(selection, /git diff --no-renames --name-only -z/)
+  })
+
   test('runs every expensive partition outside pull requests', () => {
     const selection = job('changes')
-    assert.match(selection, /git diff --no-renames --name-only -z/)
     assert.match(selection, /if:\s*github\.event_name != 'pull_request'/)
     for (const output of ['compare', 'stress']) {
       assert.match(selection, new RegExp(`echo '${output}=true'`))


### PR DESCRIPTION
Fixes the change selector for long-lived pull requests.\n\nThe selector previously checked out only two commits, then required the pull request event's base SHA. When that base is older than the merge ref's current parents, the SHA is missing and classification fails before tests run. PR #54 reproduced this with a base seven commits behind current main.\n\nThe selector now fetches complete history, matching the static job. A workflow contract test locks that checkout depth.\n\n## Verification\n\n- Reproduced the missing-base failure from PR #54 run 34410960489.\n- The exact PR #54 diff classifies as static=docs, compare=false, stress=false when both commits are available.\n- CI workflow contract tests pass, 17 tests.\n- Workflow and test formatting pass.\n- Git diff checks pass.\n\nNo changeset is needed because this only changes repository CI tooling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated pull request change detection to fetch the complete repository history before classifying changes.

- **Tests**
  - Added coverage verifying full-history checkout behavior during pull request change detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->