### PR TITLE
Honor authored case heights in conformance checks

### DIFF
--- a/API-FRICTION.md
+++ b/API-FRICTION.md
@@ -8282,6 +8282,15 @@ Each entry records:
 - Verification: metadata tests accept the dashboard's 860-pixel height, the
   conformance example build passes, and Chromium renders both comparison panels
   at 960 by 860 pixels without root overflow.
+- Follow-up observed in nightly run 34598495700: the standalone conformance
+  runner still forced 360 pixels despite the shadcn cases declaring 600. Carry
+  case height through timing mounts and updates, visual comparisons,
+  screenshots, and interaction revisions, and retain 360 only as the default.
+  A focused standard Chromium run now contains both renderers' area-linear
+  labels at all three widths in both themes, before and after updates. The
+  default-height pointer-tooltip case passes its visual and interaction checks.
+  The area case still correctly fails its separate Recharts accessible-name
+  check; no accessibility, paint, or geometry gate was relaxed.
 
 ### F-274 — Upstream example clones had no drift boundary
 

--- a/scripts/compare-plot-catalog-helpers.mjs
+++ b/scripts/compare-plot-catalog-helpers.mjs
@@ -1,5 +1,9 @@
 import { selectWeightedShard } from './benchmark/filters.mjs'
 
+export function conformanceCaseHeight(entry) {
+  return entry.height ?? 360
+}
+
 export function selectCatalogCases(cases, caseFilter, shard, weightFor) {
   const filteredCases = cases.filter(
     (entry) => !caseFilter || caseFilter.has(entry.id),

--- a/scripts/compare-plot-catalog-helpers.mjs
+++ b/scripts/compare-plot-catalog-helpers.mjs
@@ -1,7 +1,11 @@
 import { selectWeightedShard } from './benchmark/filters.mjs'
 
 export function conformanceCaseHeight(entry) {
-  return entry.height ?? 360
+  const height = entry.height === undefined ? 360 : entry.height
+  if (!Number.isFinite(height) || height <= 0) {
+    throw new TypeError(`Invalid conformance height for ${entry.id ?? 'case'}`)
+  }
+  return height
 }
 
 export function selectCatalogCases(cases, caseFilter, shard, weightFor) {

--- a/scripts/compare-plot-catalog-helpers.test.mjs
+++ b/scripts/compare-plot-catalog-helpers.test.mjs
@@ -15,6 +15,24 @@ describe('catalog comparison helpers', () => {
     assert.equal(conformanceCaseHeight({ height: 600 }), 600)
     assert.equal(conformanceCaseHeight({ height: 860 }), 860)
   })
+  test('rejects invalid authored heights instead of coercing or defaulting', () => {
+    for (const height of [
+      0,
+      -1,
+      NaN,
+      Infinity,
+      -Infinity,
+      '600',
+      null,
+      false,
+    ]) {
+      assert.throws(
+        () => conformanceCaseHeight({ height }),
+        /Invalid conformance height/,
+      )
+    }
+    assert.equal(conformanceCaseHeight({ height: 600.5 }), 600.5)
+  })
   const cases = [
     { id: 'alpha', weight: 2 },
     { id: 'beta', weight: 1 },

--- a/scripts/compare-plot-catalog-helpers.test.mjs
+++ b/scripts/compare-plot-catalog-helpers.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import {
+  conformanceCaseHeight,
   normalizeTypeDiagnosticPath,
   selectCatalogCases,
 } from './compare-plot-catalog-helpers.mjs'
@@ -9,6 +10,11 @@ const { describe, test } = process.env.VITEST
   : await import('node:test')
 
 describe('catalog comparison helpers', () => {
+  test('uses authored case heights without changing the legacy default', () => {
+    assert.equal(conformanceCaseHeight({}), 360)
+    assert.equal(conformanceCaseHeight({ height: 600 }), 600)
+    assert.equal(conformanceCaseHeight({ height: 860 }), 860)
+  })
   const cases = [
     { id: 'alpha', weight: 2 },
     { id: 'beta', weight: 1 },

--- a/scripts/compare-plot-catalog.mjs
+++ b/scripts/compare-plot-catalog.mjs
@@ -19,6 +19,7 @@ import { conformanceArtifactStem } from './benchmark/conformance-artifacts.mjs'
 import { estimateConformanceCaseWeight } from './benchmark/conformance-sharding.mjs'
 import { assertKnownFilterValues, parseShard } from './benchmark/filters.mjs'
 import {
+  conformanceCaseHeight,
   normalizeTypeDiagnosticPath,
   selectCatalogCases,
 } from './compare-plot-catalog-helpers.mjs'
@@ -224,6 +225,9 @@ const result = {
     isolatedBundles: true,
     width: 640,
     height: 360,
+    caseHeights: Object.fromEntries(
+      selectedCases.map((entry) => [entry.id, conformanceCaseHeight(entry)]),
+    ),
     variants: profile.widths.flatMap((width) =>
       profile.themes.map((theme) => ({ width, theme })),
     ),
@@ -1258,18 +1262,21 @@ async function measureImplementation(
   selectedProfile,
 ) {
   const page = await browser.newPage({
-    viewport: { width: 1_120, height: 620 },
+    viewport: {
+      width: 1_120,
+      height: Math.max(620, conformanceCaseHeight(entry) + 96),
+    },
     deviceScaleFactor: 1,
     reducedMotion: 'reduce',
   })
   try {
     await page.goto(serverUrl, { waitUntil: 'load' })
     return await page.evaluate(
-      async ({ moduleUrl, caseId, renderer, warmup, samples }) => {
+      async ({ moduleUrl, caseId, renderer, warmup, samples, height }) => {
         const { mount } = await import(moduleUrl)
         await document.fonts?.ready
-        const inputA = { width: 640, height: 360, revision: 0 }
-        const inputB = { width: 640, height: 360, revision: 1 }
+        const inputA = { width: 640, height, revision: 0 }
+        const inputB = { width: 640, height, revision: 1 }
         const mountSamples = []
         let output
 
@@ -1311,7 +1318,7 @@ async function measureImplementation(
         function createContainer(width) {
           const container = document.createElement('div')
           container.style.width = `${width}px`
-          container.style.height = '360px'
+          container.style.height = `${height}px`
           document.body.append(container)
           return container
         }
@@ -1375,6 +1382,7 @@ async function measureImplementation(
         moduleUrl: `${serverUrl}bundles/${implementation.id}.js`,
         caseId: entry.id,
         renderer: implementation.renderer,
+        height: conformanceCaseHeight(entry),
         warmup: selectedProfile.warmup,
         samples: selectedProfile.samples,
       },
@@ -1409,7 +1417,10 @@ async function compareVisuals(
   }
 
   const page = await browser.newPage({
-    viewport: { width: 2_080, height: 620 },
+    viewport: {
+      width: 2_080,
+      height: Math.max(620, conformanceCaseHeight(entry) + 96),
+    },
     deviceScaleFactor: 1,
     reducedMotion: 'reduce',
   })
@@ -1425,6 +1436,7 @@ async function compareVisuals(
         guideAssertions,
         widths,
         themes,
+        height,
       }) => {
         const [{ mount: mountReference }, { mount: mountTanstack }] =
           await Promise.all([import(referenceUrl), import(tanstackUrl)])
@@ -1445,10 +1457,10 @@ async function compareVisuals(
         for (const theme of themes) {
           applyTheme(theme)
           for (const width of widths) {
-            const input = { width, height: 360, revision: 0 }
+            const input = { width, height, revision: 0 }
             for (const container of [referenceContainer, tanstackContainer]) {
               container.style.width = `${width}px`
-              container.style.minHeight = '360px'
+              container.style.minHeight = `${height}px`
               container.style.color = theme === 'dark' ? '#edf2fb' : '#172033'
               container.style.background =
                 theme === 'dark' ? '#151a24' : '#ffffff'
@@ -2340,12 +2352,16 @@ async function compareVisuals(
         guideAssertions: entry.guideAssertions ?? [],
         widths: selectedProfile.widths,
         themes: selectedProfile.themes,
+        height: conformanceCaseHeight(entry),
       },
     )
 
-    await page.setViewportSize({ width: 1_360, height: 500 })
+    await page.setViewportSize({
+      width: 1_360,
+      height: Math.max(500, conformanceCaseHeight(entry) + 96),
+    })
     await page.evaluate(
-      async ({ referenceUrl, tanstackUrl }) => {
+      async ({ referenceUrl, tanstackUrl, height }) => {
         document.body.replaceChildren()
         document.body.style.margin = '0'
         document.body.style.padding = '20px'
@@ -2359,16 +2375,17 @@ async function compareVisuals(
         for (const mount of [mountReference, mountTanstack]) {
           const panel = document.createElement('div')
           panel.style.width = '640px'
-          panel.style.minHeight = '360px'
+          panel.style.minHeight = `${height}px`
           panel.style.background = '#ffffff'
           document.body.append(panel)
-          mount(panel, { width: 640, height: 360, revision: 0 })
+          mount(panel, { width: 640, height, revision: 0 })
         }
         await document.fonts?.ready
       },
       {
         referenceUrl: `${serverUrl}bundles/${reference.id}.js`,
         tanstackUrl: `${serverUrl}bundles/${tanstack.id}.js`,
+        height: conformanceCaseHeight(entry),
       },
     )
     await page.screenshot({
@@ -2444,14 +2461,14 @@ async function compareBehaviors(
             serverUrl,
             reference,
             entry.interactionScenarios,
-            { width, theme, revision },
+            { width, height: conformanceCaseHeight(entry), theme, revision },
           ),
           tanstack: await runBehaviorImplementation(
             browser,
             serverUrl,
             tanstack,
             entry.interactionScenarios,
-            { width, theme, revision },
+            { width, height: conformanceCaseHeight(entry), theme, revision },
           ),
         }
         variants.push(pair)
@@ -2481,7 +2498,7 @@ async function runBehaviorImplementation(
   const page = await browser.newPage({
     viewport: {
       width: Math.max(variant.width + 96, 480),
-      height: 560,
+      height: Math.max(560, variant.height + 96),
     },
     deviceScaleFactor: 1,
     hasTouch: scenarios.some((scenario) =>
@@ -2504,7 +2521,7 @@ async function runBehaviorImplementation(
       page.on('pageerror', handlePageError)
       try {
         const mountResult = await page.evaluate(
-          async ({ moduleUrl, width, revision, theme }) => {
+          async ({ moduleUrl, width, height, revision, theme }) => {
             document.body.replaceChildren()
             document.documentElement.scrollTop = 0
             document.body.style.margin = '0'
@@ -2528,7 +2545,7 @@ async function runBehaviorImplementation(
             const container = document.createElement('div')
             container.dataset.conformanceRoot = ''
             container.style.width = `${width}px`
-            container.style.minHeight = '360px'
+            container.style.minHeight = `${height}px`
             container.style.background =
               theme === 'dark' ? '#151a24' : '#ffffff'
             const scrollProbe = document.createElement('div')
@@ -2538,7 +2555,7 @@ async function runBehaviorImplementation(
             const { mount } = await import(moduleUrl)
             const handle = mount(container, {
               width,
-              height: 360,
+              height,
               revision,
               interactive: true,
               behavior: true,
@@ -2741,20 +2758,21 @@ async function performBehaviorStep(page, step, variant, context) {
     }
     case 'update': {
       await page.evaluate(
-        ({ width, revision }) => {
+        ({ width, height, revision }) => {
           const behavior = globalThis.__conformanceBehavior
           if (!behavior) {
             throw new Error('conformance behavior mount is unavailable')
           }
           behavior.handle.update({
             width,
-            height: 360,
+            height,
             revision,
           })
           behavior.revision = revision
         },
         {
           width: variant.width,
+          height: variant.height,
           revision: step.revision,
         },
       )

--- a/scripts/compare-plot-catalog.mjs
+++ b/scripts/compare-plot-catalog.mjs
@@ -345,6 +345,7 @@ function validateCase(value, path) {
     typeof value.ai?.create === 'string' &&
     typeof value.ai?.maintain === 'string'
   if (!valid) throw new TypeError(`Invalid conformance metadata: ${path}`)
+  conformanceCaseHeight(value)
 }
 
 function isGeometryCount(value) {


### PR DESCRIPTION
## Fix

The conformance runner forced a 360px height even when a case declared 600px. Wider shadcn cards were clipped in both renderers. Use the declared height for timing mounts and updates, visual checks, screenshots, and interaction revisions. Keep 360px as the default and record each case height in the result protocol.

## Verification

- 72 focused benchmark, workflow, and helper tests pass.
- Formatting and diff checks pass.
- Standard headless Chromium checks at 320, 640, and 960px in both themes confirm the area-linear labels are contained before and after updates.
- The default-height pointer-tooltip case passes visual and interaction checks.

The area-linear case still fails its separate Recharts accessible-name check. Nightly run 34598495700 also exposed paint and radial-shape geometry discrepancies. This PR fixes the height bug only and does not weaken those gates.

No new CI jobs, samples, or timeouts. No published package changes or release needed.

Failure evidence: https://github.com/TanStack/charts/actions/runs/34598495700

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Conformance comparisons now honor each chart case’s configured height across rendering, screenshots, visual comparisons, and interaction checks.
  - Cases without a specified height continue to use the 360-pixel default.
  - Invalid or non-positive chart heights are now rejected during validation.
  - Area-chart labels remain consistent across supported widths and themes before and after updates.
  - Pointer-tooltip checks pass at the default height, while the existing area-chart accessibility issue remains reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->